### PR TITLE
allow for resistorMode on pushbutton constructor.

### DIFF
--- a/Source/Meadow.Foundation/Sensors/Buttons/PushButton.cs
+++ b/Source/Meadow.Foundation/Sensors/Buttons/PushButton.cs
@@ -93,13 +93,12 @@ namespace Meadow.Foundation.Sensors.Buttons
         /// Creates PushButto a digital input port connected on a IIOdevice, especifying Interrupt Mode, Circuit Type and optionally Debounce filter duration.
         /// </summary>
         /// <param name="device"></param>
-        /// <param name="inputPin"></param>
-        /// <param name="debounceDuration"></param>
-        public PushButton(IIODevice device, IPin inputPin, int debounceDuration = 20)
+        /// <param name="inputPin">The input pin to bind this button to.</param>
+        /// <param name="debounceDuration">the duration in miliseconds to debounce the button for</param>
+		/// <param name="resistorMode">Pull up or pull down</param>
+        public PushButton(IIODevice device, IPin inputPin, ResistorMode resistorMode = ResistorMode.Disabled, int debounceDuration = 20)
         {
-            // if we terminate in ground, we need to pull the port high to test for circuit completion, otherwise down.
-            var resistorMode = ResistorMode.Disabled;            
-
+            // if we terminate in ground, we need to pull the port high to test for circuit completion, otherwise down.    
             DigitalIn = device.CreateDigitalInputPort(inputPin, InterruptMode.EdgeBoth, resistorMode, debounceDuration);
             DigitalIn.Changed += DigitalInChanged;
         }

--- a/Source/Meadow.Foundation/Sensors/Rotary/RotaryEncoderWithButton.cs
+++ b/Source/Meadow.Foundation/Sensors/Rotary/RotaryEncoderWithButton.cs
@@ -46,10 +46,10 @@ namespace Meadow.Foundation.Sensors.Rotary
         /// <param name="buttonPin"></param>
         /// <param name="buttonCircuitTerminationType"></param>
         /// <param name="debounceDuration"></param>
-        public RotaryEncoderWithButton(IIODevice device, IPin aPhasePin, IPin bPhasePin, IPin buttonPin, int debounceDuration = 20)
+        public RotaryEncoderWithButton(IIODevice device, IPin aPhasePin, IPin bPhasePin, IPin buttonPin, ResistorMode resistorMode = ResistorMode.Disabled, int debounceDuration = 20)
             : base(device, aPhasePin, bPhasePin)
         {
-            _button = new PushButton(device, buttonPin, debounceDuration);
+            _button = new PushButton(device, buttonPin, resistorMode, debounceDuration);
 
             _button.Clicked += ButtonClicked;
             _button.PressEnded += ButtonPressEnded;


### PR DESCRIPTION
This addresses [Issue 13](https://github.com/WildernessLabs/Meadow.Foundation/issues/13). For some reason the resistor mode was being set inside the constructor instead of as a user supplied value to the constructor. Changed implimentation and updated summary.