### PR TITLE
update driver to avoid blanking the line before writing the new text

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Displays.Lcd.CharacterDisplay/Driver/Displays.Lcd.CharacterDisplay/CharacterDisplay.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Lcd.CharacterDisplay/Driver/Displays.Lcd.CharacterDisplay/CharacterDisplay.cs
@@ -153,10 +153,11 @@ namespace Meadow.Foundation.Displays.Lcd
 
         public void WriteLine(string text, byte lineNumber)
         {
-            ClearLine(lineNumber);
             SetLineAddress(lineNumber);
 
-            var bytes = System.Text.Encoding.UTF8.GetBytes(text);
+            // Instead of clearing the line first, pad it with empty space on the end
+            var paddedString = text.PadRight(DisplayConfig.Width, ' ');
+            var bytes = System.Text.Encoding.UTF8.GetBytes(paddedString);
             foreach (var b in bytes)
             {
                 SendByte(b, LCD_DATA);


### PR DESCRIPTION
We can avoid the cost of writing blanks to the entire line on each `WriteLine` by padding the end of the string with spaces before writing it.