### PR TITLE
PushButton: unify whitespace

### DIFF
--- a/Source/Meadow.Foundation.Core/Sensors/Buttons/PushButton.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Buttons/PushButton.cs
@@ -248,9 +248,9 @@ namespace Meadow.Foundation.Sensors.Buttons
         /// Raised when the button circuit is re-opened after it has been closed (at the end of a �press�).
         /// </summary>
         protected virtual void RaiseClicked ()
-		{
-			this._clicked (this, EventArgs.Empty);
-		}
+        {
+                this._clicked (this, EventArgs.Empty);
+        }
 
         /// <summary>
         /// Raised when a press starts (the button is pushed down; circuit is closed).


### PR DESCRIPTION
While testing out the [code in the PushButton PR](https://github.com/WildernessLabs/Meadow.Foundation/pull/34), I noticed this inconsistent leading whitespace as part of a merge conflict for that PR branch.