### PR TITLE
Fixes #46

### DIFF
--- a/Source/Meadow.Foundation.Core/Sensors/Temperature/AnalogTemperatureSensor.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Temperature/AnalogTemperatureSensor.cs
@@ -299,9 +299,9 @@ namespace Meadow.Foundation.Sensors.Temperature
         /// <param name="voltage"></param>
         /// <returns></returns>
         protected float VoltageToTemperature(float voltage)
-        {  
-            var yAdjusted = voltage * 1000 - _yIntercept;
-            return yAdjusted * _millivoltsPerDegreeCentigrade * 10;
+        {
+            var yAdjusted = voltage * 1000;
+            return (yAdjusted - _yIntercept) * 1000 / _millivoltsPerDegreeCentigrade;
         }
 
         #endregion Methods


### PR DESCRIPTION
Correct calculation for sensors that don't use 10mV per degCelsius.
Still returns degrees Celsius * 1000.
Closes #46, and based on the suggested fix there.