### PR TITLE
Fix rotation rotary encoder with button

### DIFF
--- a/Source/Meadow.Foundation.Core.Samples/Sensors.Rotary.RotaryEncoderWithButton_Sample/MeadowApp.cs
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.Rotary.RotaryEncoderWithButton_Sample/MeadowApp.cs
@@ -14,7 +14,7 @@ namespace Sensors.Rotary.RotaryEncoderWithButton_Sample
         {
             Console.WriteLine("Initializing...");
 
-            rotaryEncoderWithButton = new RotaryEncoderWithButton(Device, Device.Pins.D15, Device.Pins.D14, Device.Pins.D13);
+            rotaryEncoderWithButton = new RotaryEncoderWithButton(Device, Device.Pins.D08, Device.Pins.D07, Device.Pins.D06); /// Changed to working pins. D14 causes issues.
             rotaryEncoderWithButton.Rotated += (s, e) =>
             {
                 if (e.Direction == Meadow.Peripherals.Sensors.Rotary.RotationDirection.Clockwise)

--- a/Source/Meadow.Foundation.Core/Meadow.Foundation.Core.csproj
+++ b/Source/Meadow.Foundation.Core/Meadow.Foundation.Core.csproj
@@ -9,7 +9,7 @@
    <PackageIconUrl>https://github.com/WildernessLabs/Meadow.Foundation/blob/master/Source/icon.png?raw=true</PackageIconUrl>
    <RepositoryUrl>https://github.com/WildernessLabs/Meadow.Foundation</RepositoryUrl>
    <PackageTags>Meadow, Meadow.Foundation</PackageTags>
-   <Version>0.14.1</Version>
+   <Version>0.14.2</Version>
    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
    <RootNamespace>Meadow.Foundation</RootNamespace>
    <IncludeSymbols>true</IncludeSymbols>

--- a/Source/Meadow.Foundation.Core/Meadow.Foundation.Core.csproj
+++ b/Source/Meadow.Foundation.Core/Meadow.Foundation.Core.csproj
@@ -9,7 +9,7 @@
    <PackageIconUrl>https://github.com/WildernessLabs/Meadow.Foundation/blob/master/Source/icon.png?raw=true</PackageIconUrl>
    <RepositoryUrl>https://github.com/WildernessLabs/Meadow.Foundation</RepositoryUrl>
    <PackageTags>Meadow, Meadow.Foundation</PackageTags>
-   <Version>0.14.2</Version>
+   <Version>0.14.1</Version>
    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
    <RootNamespace>Meadow.Foundation</RootNamespace>
    <IncludeSymbols>true</IncludeSymbols>

--- a/Source/Meadow.Foundation.Core/Sensors/Rotary/RotaryEncoderWithButton.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Rotary/RotaryEncoderWithButton.cs
@@ -42,12 +42,12 @@ namespace Meadow.Foundation.Sensors.Rotary
         /// <param name="aPhasePin"></param>
         /// <param name="bPhasePin"></param>
         /// <param name="buttonPin"></param>
-        /// <param name="buttonCircuitTerminationType"></param>
+        /// <param name="resistor"></param>
         /// <param name="debounceDuration"></param>
-        public RotaryEncoderWithButton(IIODevice device, IPin aPhasePin, IPin bPhasePin, IPin buttonPin, int debounceDuration = 20)
+        public RotaryEncoderWithButton(IIODevice device, IPin aPhasePin, IPin bPhasePin, IPin buttonPin, ResistorMode resistor = ResistorMode.PullDown, int debounceDuration = 20)
             : base(device, aPhasePin, bPhasePin)
         {
-            _button = new PushButton(device, buttonPin, debounceDuration);
+            _button = new PushButton(device, buttonPin,resistor, debounceDuration);
 
             _button.Clicked += ButtonClicked;
             _button.PressEnded += ButtonPressEnded;


### PR DESCRIPTION
This address issue #70  and also improves the logic within the RotaryEncoder class. Incorporated the fix in Pull Request #34 to address the button firing opposite events. 

The major change to the RotaryEncoder was to monitor the events separately. The previous logic was not handling bad digital events properly and could leave no values incrementing. This version still has issues with handling speed of rotation (rotation direction does get missed) however, it does not flag on improper clock events. I also significantly reduced the denounce as the new software logic allows for a lot faster readings. It will still glitch if you turn it to rapidly but will recover now (previously it would not)

Better ways to address the button issue or the events triggering are always welcome! The same demo circuit on the website can be used with notable changes to the pins to verify that the code is working.