### PR TITLE
Remove second multiplication by 1000

### DIFF
--- a/Source/Meadow.Foundation.Core/Sensors/Temperature/AnalogTemperatureSensor.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Temperature/AnalogTemperatureSensor.cs
@@ -302,7 +302,7 @@ namespace Meadow.Foundation.Sensors.Temperature
         protected float VoltageToTemperature(float voltage)
         {
             var yAdjusted = voltage * 1000;
-            return (yAdjusted - _yIntercept) * 1000 / _millivoltsPerDegreeCentigrade;
+            return (yAdjusted - _yIntercept) / _millivoltsPerDegreeCentigrade;
         }
 
         #endregion Methods


### PR DESCRIPTION
In VoltageToTemperature method yAdjusted value will be in millivolts.
The calculation to convert millivolts to temperature does not require multiplying by 1000.