### PR TITLE
Fixed offset issue when using LedBarGraph.Percentage with >20 LEDs

### DIFF
--- a/Source/Meadow.Foundation.Core/Leds/LedBarGraph.cs
+++ b/Source/Meadow.Foundation.Core/Leds/LedBarGraph.cs
@@ -113,7 +113,7 @@ namespace Meadow.Foundation.Leds
             float value = percentage * Count;
             
             if (_isPwm == false)
-                value += 0.5f;
+                value += (Count == 0 ? 0.5f : (0.5f / Count));
 
             for (int i = 1; i <= Count; i++)
             {


### PR DESCRIPTION
When lighting a percentage of non-pwm lights, 0.5 is added to the percentage. This is to stop floating point equality errors and works fine for 10 LEDs. However, if you map 20 or more LEDs into a LedBarGraph this results in 1 or more LEDs being erroneously turned on.

The fix is to instead add half of the increment, or `0.5 * (1 / LedCount)`