### PR TITLE
Changed Is<sensor>Calibrated methods behavior to return true only, wh…

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Bno055/Driver/Sensors.Motion.BNO055/BNO055.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Bno055/Driver/Sensors.Motion.BNO055/BNO055.cs
@@ -1739,7 +1739,7 @@ namespace Meadow.Foundation.Sensors.Motion
 	    {
 	        get
 	        {
-	            return (((bno055.ReadRegister(Registers.CalibrationStatus) >> 6) & 0x03) != 0);
+	            return (((bno055.ReadRegister(Registers.CalibrationStatus) >> 6) & 0x03) == 3);
 	        }
 	    }
 
@@ -1750,7 +1750,7 @@ namespace Meadow.Foundation.Sensors.Motion
 	    {
 	        get
 	        {
-	            return (((bno055.ReadRegister(Registers.CalibrationStatus) >> 2) & 0x03) != 0);
+	            return (((bno055.ReadRegister(Registers.CalibrationStatus) >> 2) & 0x03) == 3);
 	        }
 	    }
 
@@ -1761,7 +1761,7 @@ namespace Meadow.Foundation.Sensors.Motion
 	    {
 	        get
 	        {
-	            return (((bno055.ReadRegister(Registers.CalibrationStatus) >> 4) & 0x03) != 0);
+	            return (((bno055.ReadRegister(Registers.CalibrationStatus) >> 4) & 0x03) == 3);
 	        }
 	    }
 
@@ -1770,7 +1770,7 @@ namespace Meadow.Foundation.Sensors.Motion
 	    /// </summary>
 	    public bool IsMagnetometerCalibrated
 	    {
-	        get { return ((bno055.ReadRegister(Registers.CalibrationStatus) & 0x03) != 0); }
+	        get { return ((bno055.ReadRegister(Registers.CalibrationStatus) & 0x03) == 3); }
 	    }
 
 	    /// <summary>
@@ -1788,7 +1788,6 @@ namespace Meadow.Foundation.Sensors.Motion
 	                    IsMagnetometerCalibrated);
 	        }
 	    }
-
         
 
         
@@ -1867,6 +1866,36 @@ namespace Meadow.Foundation.Sensors.Motion
             DebugInformation.DisplayRegisters(0x00, registers);
         }
 
-		
-	}
+
+        /// <summary>
+        ///     As Bno055 callibration might be value between 0 and 3 return exact calibration values
+        /// </summary>
+        /// <returns>Byte array with calibration values</returns>
+        public byte[] GetCalibrationValues()
+        {
+            byte callibration = bno055.ReadRegister(Registers.CalibrationStatus);
+            byte system = (byte)((callibration >> 6) & 3);
+            byte gyro = (byte)((callibration >> 4) & 3);
+            byte acc = (byte)((callibration >> 2) & 3);
+            byte mag = (byte)((callibration) & 3);
+            return new byte[] { system, gyro, acc, mag };
+        }
+
+        /// <summary>
+        ///     Read euler angles straight from registers
+        /// </summary>
+        /// <returns>Float array with euler angles</returns>
+        internal float[] ReadEulerAngles()
+        {
+            float divisor = orientationUnits == Units.Degrees ? 16f : 900f;
+            byte[] data = bno055.ReadRegisters(0x1a, 6);
+            float[] result = new float[]
+            {
+                (short)((data[1] << 8) | data[0])/divisor,
+                (short)((data[3] << 8) | data[2])/divisor,
+                (short)((data[5] << 8) | data[4])/divisor
+            };
+            return result;
+        }
+    }
 }


### PR DESCRIPTION
**Calibration**
Bno calibration status is value between 0 and 3. Up until now Is<sensor>Calibrated methods returned true when value was different than 0. Gyro and Mag get calibrated quickly to 3, but for accelerometer it might take quite some time to calibrate to 3, so it could be stuck at lower value and there was no way of getting that information. I've changed those methods to return true only, when calibrations values are 3, so we have best calibration possible. Also added method that returns exact values, so we can track calibration progress easily. 

**Reading Euler angles**
Current methods in driver use double, while results are float and also STM is 32bit device, so double is much less efficient. 
In my method it takes around 2.7ms to get float with Euler angles, while driver's one takes ~23.6ms, so almost 10 times faster. For applications that need constant updates I think it's a big difference. I've added same public method to get it that way.

New method just reads straight from Bno055's registers (the one I used in my device for tests):

```
I2cPeripheral bno = new I2cPeripheral(bus, address);
float representationInLSB = 16;
internal float[] Read()
{
    byte[] data = bno.ReadRegisters(0x1a, 6);
    float[] result = new float[]
    {
        (short)((data[1] << 8) | data[0])/representationInLSB,
        (short)((data[3] << 8) | data[2])/representationInLSB,
        (short)((data[5] << 8) | data[4])/representationInLSB,
    };
    return result;
}

```

And test code I'm using:

```
private void Test()
{
    stopwatch.Start();
    for (int i = 0; i < 100; i++)
    {
        float[] result = Read(); 
    }
    stopwatch.Stop();
    Console.WriteLine(stopwatch.ElapsedMilliseconds);
    stopwatch.Reset();
    stopwatch.Start();
    for (int i = 0; i < 100; i++)
    {
        sensor.Read();
        double[] readings = new double[] { sensor.EulerOrientation.Heading, sensor.EulerOrientation.Roll, sensor.EulerOrientation.Pitch }; 
    }
    stopwatch.Stop();
    Console.WriteLine(stopwatch.ElapsedMilliseconds);
    stopwatch.Reset();
}
```

And sample results:

 270
 2362
 
 270
 2364
 
 271
 2380
 
 270
 2361
 
 268
 2359