### PR TITLE
Added class HallEffectCounter allowing to use hall effect sensor to count signals

### DIFF
--- a/Source/Meadow.Foundation.Core/Sensors/HallEffect/HallEffectCounter.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/HallEffect/HallEffectCounter.cs
@@ -1,0 +1,113 @@
+﻿using Meadow.Hardware;
+using System;
+
+namespace Meadow.Foundation.Sensors.HallEffect
+{
+    /// <summary>
+    /// Allows use of Hall effect sensor for counting magnetic field changes,
+    /// For example for counting wheel rotations to get distance traveled,
+    /// Or magnetic field blocking objects passing between sensor and magnet
+    /// </summary>
+    class HallEffectCounter
+    {
+        IDigitalInputPort port;
+        private int counter = 0;
+        //-1 so it wont fire LimitReached unnecessary
+        private int targetCount = -1;
+        //Allows to get current count since last reset
+        public int Counter { get => counter; }
+
+        EventHandler LimitReached;
+        EventHandler<int> CountChanged;
+
+        public HallEffectCounter(IDigitalInputPort p)
+        {
+            port = p;
+            port.Changed += Port_Changed;
+        }
+
+        /// <summary>
+        /// Fires apropriate events
+        /// </summary>
+        /// <param name="sender">Sender</param>
+        /// <param name="e">Args</param>
+        private void Port_Changed(object sender, DigitalInputPortEventArgs e)
+        {
+            counter++;
+            if (CountChanged != null) OnCountChanged();
+            if (counter == targetCount && LimitReached != null) OnLimitReached();
+        }
+
+        /// <summary>
+        /// Resets counter
+        /// </summary>
+        private void ResetCount()
+        {
+            counter = 0;
+        }
+
+        /// <summary>
+        /// Fires when count changes, informs about current count
+        /// </summary>
+        private void OnCountChanged()
+        {
+            CountChanged?.Invoke(this, counter);
+        }
+
+        /// <summary>
+        /// Fires when count reaches preset target
+        /// </summary>
+        private void OnLimitReached()
+        {
+            LimitReached?.Invoke(this, null);
+        }
+
+        /// <summary>
+        /// Sets target to -1 so OnLimitReached won't be invoked
+        /// </summary>
+        public void DisableTarget()
+        {
+            targetCount = -1;
+        }
+
+        /// <summary>
+        /// Sets new target and resets counter to start counting towards it
+        /// </summary>
+        /// <param name="target">Count to reach</param>
+        public void SetTarget(int target)
+        {
+            ResetCount();
+            targetCount = target;
+        }
+
+        /// <summary>
+        /// Allows other classes to register methods to be invoked when count changes 
+        /// </summary>
+        /// <param name="handler">Method to be invoked when count changes</param>
+        public void RegisterForCount(EventHandler<int> handler)
+        {
+            CountChanged += handler;
+        }
+
+        /// <summary>
+        /// Allows other classes to register methods to be invoked when target count is reached
+        /// </summary>
+        /// <param name="handler">Method to be invoked when target count reached</param>
+        public void RegisterForLimitReached(EventHandler handler)
+        {
+            LimitReached += handler;
+        }
+
+        /// <summary>
+        /// Allows other classes to register methods to be invoked when target count is reached.
+        /// Allows also to pass new target count at the same time
+        /// </summary>
+        /// <param name="handler">Method to be invoked when target count reached</param>
+        /// <param name="target">Count to reach</param>
+        public void RegisterForLimitReached(EventHandler handler, int target)
+        {
+            SetTarget(target);
+            LimitReached += handler;
+        }
+    }
+}


### PR DESCRIPTION
Previous Hall effect sensor class allows only use as a tachometer. This is class I developed for my project, where I'm using it to count wheel rotations to measure distance traveled by vehicle, could also be used in different scenarios, maybe linear move over track with magnets, or counting magnetic field blocking objects passing between sensor and magnet (maybe for example coins put into device, probably would be able to use maybe with teeth of sprocket, although I haven't tried, etc.) 

Example use:

```
private AutoResetEvent auto = new AutoResetEvent(false);
private readonly float circumference = 0.15 //m
private HallEffectCounter counter;

public Constructor()
{
    counter = new HallEffectCounter(pinHere);
    counter.RegisterForLimitReached(Stop);
{

private void Stop(object sender, EventArgs e)
{
    autoReset.Set();
    (sender as HallEffectCounter).DisableTarget();
}

public void DrivePreselectedDistance(float distance)
{
    int rotations = (int)Math.Round(distance/circumference);
    counter.SetTarget(5);
    SomeMethodToStartMotor();
    auto.WaitOne();
    SomeMethodToStopMotor();
}
```

When vehicle will move, execution will be stopped on WaitOne() and counter will count rotations (or can be fractions of rotations with corresponding distance declared) and when vehicle will travel distance equal to required one (rounded to step size defined by circumference here) AutoResetEvent will be set and will allow program to get to line stopping vehicle