### PR TITLE
Add obsolete methods for API changes

### DIFF
--- a/Source/Meadow.Foundation.Core/Color.cs
+++ b/Source/Meadow.Foundation.Core/Color.cs
@@ -23,7 +23,6 @@ namespace Meadow.Foundation
             get { return _mode == Mode.Default; }
         }
         
-
         public double A
         {
             get { return a; }
@@ -340,7 +339,7 @@ namespace Meadow.Foundation
             }
         }
 
-        public static Color FromUint(int argb)
+        public static Color FromUint(uint argb)
         {
             return FromRgba((byte)((argb & 0x00ff0000) >> 0x10), (byte)((argb & 0x0000ff00) >> 0x8), (byte)(argb & 0x000000ff), (byte)((argb & 0xff000000) >> 0x18));
         }

--- a/Source/Meadow.Foundation.Core/Color.cs
+++ b/Source/Meadow.Foundation.Core/Color.cs
@@ -281,19 +281,19 @@ namespace Meadow.Foundation
             return "[Color: A={" + A + "}, R={" + R + "}, G={" + G + "}, B={" + B + "}, Hue={" + Hue + "}, Saturation={" + Saturation + "}, Brightness={" + Brightness + "}]";
         }
 
-        static int ToHex(char c)
+        static uint ToHex(char c)
         {
             ushort x = (ushort)c;
             if (x >= '0' && x <= '9')
-                return (x - '0');
+                return (uint)(x - '0');
 
             x |= 0x20;
             if (x >= 'a' && x <= 'f')
-                return (x - 'a' + 10);
+                return (uint)(x - 'a' + 10);
             return 0;
         }
 
-        static int ToHexD(char c)
+        static uint ToHexD(char c)
         {
             var j = ToHex(c);
             return (j << 4) | j;

--- a/Source/Meadow.Foundation.Core/Leds/Led.cs
+++ b/Source/Meadow.Foundation.Core/Leds/Led.cs
@@ -1,5 +1,6 @@
 using Meadow.Hardware;
 using Meadow.Peripherals.Leds;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -93,6 +94,24 @@ namespace Meadow.Foundation.Leds
 			}
 
 			Port.State = IsOn;
+		}
+
+		/// <summary>
+		/// Blink animation that turns the LED on and off based on the OnDuration and offDuration values in ms
+		/// </summary>
+		/// <param name="onDuration"></param>
+		/// <param name="offDuration"></param>
+		[Obsolete("Method deprecated: use StartBlink(int onDuration, int offDuration)")]
+		public void StartBlink(uint onDuration = 200, uint offDuration = 200)
+		{
+			Stop();
+
+			animationTask = new Task(async () =>
+			{
+				cancellationTokenSource = new CancellationTokenSource();
+				await StartBlinkAsync((int)onDuration, (int)offDuration, cancellationTokenSource.Token);
+			});
+			animationTask.Start();
 		}
 	}
 }

--- a/Source/Meadow.Foundation.Core/Leds/Led.cs
+++ b/Source/Meadow.Foundation.Core/Leds/Led.cs
@@ -102,7 +102,7 @@ namespace Meadow.Foundation.Leds
 		/// <param name="onDuration"></param>
 		/// <param name="offDuration"></param>
 		[Obsolete("Method deprecated: use StartBlink(int onDuration, int offDuration)")]
-		public void StartBlink(uint onDuration = 200, uint offDuration = 200)
+		public void StartBlink(uint onDuration, uint offDuration)
 		{
 			Stop();
 

--- a/Source/Meadow.Foundation.Core/Leds/LedBarGraph.cs
+++ b/Source/Meadow.Foundation.Core/Leds/LedBarGraph.cs
@@ -143,5 +143,53 @@ namespace Meadow.Foundation.Leds
                 led.Stop();
             }
         }
+
+        /// <summary>
+        /// Set the LED state
+        /// </summary>
+        /// <param name="index">index of the LED</param>
+        /// <param name="isOn"></param>
+        [Obsolete("Method deprecated: use SetLed(int index, bool isOn)")]
+        public void SetLed(uint index, bool isOn)
+        {
+            if (index >= Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            leds[index].Stop();
+            leds[index].IsOn = isOn;
+        }
+
+        /// <summary>
+        /// Blink animation that turns the LED bar graph on and off based on the OnDuration and offDuration values in ms
+        /// </summary>
+        /// <param name="onDuration"></param>
+        /// <param name="offDuration"></param>
+        [Obsolete("Method deprecated: use StartBlink(int onDuration, int offDuration)")]
+        public void StartBlink(uint onDuration = 200, uint offDuration = 200)
+        {
+            foreach (var led in leds)
+            {
+                led.StartBlink(onDuration, offDuration);
+            }
+        }
+
+        /// <summary>
+        /// Starts a blink animation on an individual LED
+        /// </summary>
+        /// <param name="index"></param>
+        /// <param name="onDuration"></param>
+        /// <param name="offDuration"></param>
+        [Obsolete("Method deprecated: use SetLedBlink(int index, int onDuration, int offDuration)")]
+        public void SetLedBlink(uint index, uint onDuration = 200, uint offDuration = 200)
+        {
+            if (index >= Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            leds[index].StartBlink(onDuration, offDuration);
+        }
     }
 }

--- a/Source/Meadow.Foundation.Core/Leds/LedBarGraph.cs
+++ b/Source/Meadow.Foundation.Core/Leds/LedBarGraph.cs
@@ -167,7 +167,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="onDuration"></param>
         /// <param name="offDuration"></param>
         [Obsolete("Method deprecated: use StartBlink(int onDuration, int offDuration)")]
-        public void StartBlink(uint onDuration = 200, uint offDuration = 200)
+        public void StartBlink(uint onDuration, uint offDuration)
         {
             foreach (var led in leds)
             {
@@ -182,7 +182,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="onDuration"></param>
         /// <param name="offDuration"></param>
         [Obsolete("Method deprecated: use SetLedBlink(int index, int onDuration, int offDuration)")]
-        public void SetLedBlink(uint index, uint onDuration = 200, uint offDuration = 200)
+        public void SetLedBlink(uint index, uint onDuration, uint offDuration)
         {
             if (index >= Count)
             {

--- a/Source/Meadow.Foundation.Core/Leds/PwmLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/PwmLed.cs
@@ -245,7 +245,7 @@ namespace Meadow.Foundation.Leds
         /// Start the Blink animation which sets the brightness of the LED alternating between a low and high brightness setting, using the durations provided.
         /// </summary>
         [Obsolete("Method deprecated: use StartBlink(int onDuration, int offDuration, float highBrightness, float lowBrightness)")]
-        public void StartBlink(uint onDuration = 200, uint offDuration = 200, float highBrightness = 1f, float lowBrightness = 0f)
+        public void StartBlink(uint onDuration, uint offDuration, float highBrightness, float lowBrightness)
         {
             if (highBrightness > 1 || highBrightness <= 0)
             {
@@ -274,7 +274,7 @@ namespace Meadow.Foundation.Leds
         /// Start the Pulse animation which gradually alternates the brightness of the LED between a low and high brightness setting, using the durations provided.
         /// </summary>        
         [Obsolete("Method deprecated: use StartPulse(int pulseDuration, float highBrightness, float lowBrightness)")]
-        public void StartPulse(uint pulseDuration = 600, float highBrightness = 1, float lowBrightness = 0.15F)
+        public void StartPulse(uint pulseDuration, float highBrightness, float lowBrightness)
         {
             if (highBrightness > 1 || highBrightness <= 0)
             {

--- a/Source/Meadow.Foundation.Core/Leds/PwmLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/PwmLed.cs
@@ -240,5 +240,63 @@ namespace Meadow.Foundation.Leds
             cancellationTokenSource?.Cancel();
             IsOn = false;
         }
+
+        /// <summary>
+        /// Start the Blink animation which sets the brightness of the LED alternating between a low and high brightness setting, using the durations provided.
+        /// </summary>
+        [Obsolete("Method deprecated: use StartBlink(int onDuration, int offDuration)")]
+        public void StartBlink(uint onDuration = 200, uint offDuration = 200, float highBrightness = 1f, float lowBrightness = 0f)
+        {
+            if (highBrightness > 1 || highBrightness <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(highBrightness), "onBrightness must be > 0 and <= 1");
+            }
+            if (lowBrightness >= 1 || lowBrightness < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(lowBrightness), "lowBrightness must be >= 0 and < 1");
+            }
+            if (lowBrightness >= highBrightness)
+            {
+                throw new Exception("offBrightness must be less than onBrightness");
+            }
+
+            Stop();
+
+            animationTask = new Task(async () =>
+            {
+                cancellationTokenSource = new CancellationTokenSource();
+                await StartBlinkAsync((int)onDuration, (int)offDuration, highBrightness, lowBrightness, cancellationTokenSource.Token);
+            });
+            animationTask.Start();
+        }
+
+        /// <summary>
+        /// Start the Pulse animation which gradually alternates the brightness of the LED between a low and high brightness setting, using the durations provided.
+        /// </summary>        
+        [Obsolete("Method deprecated: use StartPulse(int pulseDuration, float highBrightness, float lowBrightness)")]
+        public void StartPulse(uint pulseDuration = 600, float highBrightness = 1, float lowBrightness = 0.15F)
+        {
+            if (highBrightness > 1 || highBrightness <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(highBrightness), "highBrightness must be > 0 and <= 1");
+            }
+            if (lowBrightness >= 1 || lowBrightness < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(lowBrightness), "lowBrightness must be >= 0 and < 1");
+            }
+            if (lowBrightness >= highBrightness)
+            {
+                throw new Exception("lowBrightness must be less than highbrightness");
+            }
+
+            Stop();
+
+            animationTask = new Task(async () =>
+            {
+                cancellationTokenSource = new CancellationTokenSource();
+                await StartPulseAsync((int)pulseDuration, highBrightness, lowBrightness, cancellationTokenSource.Token);
+            });
+            animationTask.Start();
+        }
     }
 }

--- a/Source/Meadow.Foundation.Core/Leds/PwmLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/PwmLed.cs
@@ -244,7 +244,7 @@ namespace Meadow.Foundation.Leds
         /// <summary>
         /// Start the Blink animation which sets the brightness of the LED alternating between a low and high brightness setting, using the durations provided.
         /// </summary>
-        [Obsolete("Method deprecated: use StartBlink(int onDuration, int offDuration)")]
+        [Obsolete("Method deprecated: use StartBlink(int onDuration, int offDuration, float highBrightness, float lowBrightness)")]
         public void StartBlink(uint onDuration = 200, uint offDuration = 200, float highBrightness = 1f, float lowBrightness = 0f)
         {
             if (highBrightness > 1 || highBrightness <= 0)

--- a/Source/Meadow.Foundation.Core/Leds/PwmLedBarGraph.cs
+++ b/Source/Meadow.Foundation.Core/Leds/PwmLedBarGraph.cs
@@ -257,7 +257,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="highBrightness"></param>
         /// <param name="lowBrightness"></param>
         [Obsolete("Method deprecated: use SetLedBlink(int index, int onDuration, int offDuration, float highBrightness, float lowBrightness)")]
-        public void SetLedBlink(uint index, uint onDuration = 200, uint offDuration = 200, float highBrightness = 1, float lowBrightness = 0)
+        public void SetLedBlink(uint index, uint onDuration, uint offDuration, float highBrightness, float lowBrightness)
         {
             if (index >= Count)
             {
@@ -277,7 +277,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="highBrightness"></param>
         /// <param name="lowBrightness"></param>
         [Obsolete("Method deprecated: use SetLedPulse(int index, int pulseDuration, float highBrightness, float lowBrightness)")]
-        public void SetLedPulse(uint index, uint pulseDuration = 600, float highBrightness = 1, float lowBrightness = 0.15F)
+        public void SetLedPulse(uint index, uint pulseDuration, float highBrightness, float lowBrightness)
         {
             if (index >= Count)
             {
@@ -295,7 +295,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="highBrightness">High brigtness.</param>
         /// <param name="lowBrightness">Low brightness.</param>
         [Obsolete("Method deprecated: use StartBlink(int onDuration, int offDuration, float highBrightness, float lowBrightness)")]
-        public void StartBlink(uint onDuration = 200, uint offDuration = 200, float highBrightness = 1, float lowBrightness = 0)
+        public void StartBlink(uint onDuration, uint offDuration, float highBrightness, float lowBrightness)
         {
             foreach (var pwmLed in pwmLeds)
             {
@@ -310,7 +310,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="lowBrightness">Low brightness.</param>
         /// </summary>
         [Obsolete("Method deprecated: use StartPulse(int pulseDuration, float highBrightness, float lowBrightness)")]
-        public void StartPulse(uint pulseDuration = 600, float highBrightness = 1, float lowBrightness = 0.15F)
+        public void StartPulse(uint pulseDuration, float highBrightness, float lowBrightness)
         {
             if (highBrightness > 1 || highBrightness <= 0)
             {

--- a/Source/Meadow.Foundation.Core/Leds/PwmLedBarGraph.cs
+++ b/Source/Meadow.Foundation.Core/Leds/PwmLedBarGraph.cs
@@ -212,5 +212,123 @@ namespace Meadow.Foundation.Leds
                 pwmLed.Stop();
             }
         }
+
+        /// <summary>
+        /// Set the brightness of an individual LED when using PWM
+        /// </summary>
+        /// <param name="index"></param>
+        /// <param name="brightness"></param>
+        [Obsolete("Method deprecated: use SetLedBrightness(int index, float brightness)")]
+        public void SetLedBrightness(uint index, float brightness)
+        {
+            if (index >= Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            pwmLeds[index].Stop();
+            pwmLeds[index].IsOn = false;
+            pwmLeds[index].SetBrightness(brightness);
+        }
+
+        /// <summary>
+        /// Set the LED state
+        /// </summary>
+        /// <param name="index">index of the LED</param>
+        /// <param name="isOn"></param>
+        [Obsolete("Method deprecated: use SetLed(int index, bool isOn)")]
+        public void SetLed(uint index, bool isOn)
+        {
+            if (index >= Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            pwmLeds[index].Stop();
+            pwmLeds[index].IsOn = isOn;
+        }
+
+        /// <summary>
+        /// Starts a blink animation on an individual LED
+        /// </summary>
+        /// <param name="index"></param>
+        /// <param name="onDuration"></param>
+        /// <param name="offDuration"></param>
+        /// <param name="highBrightness"></param>
+        /// <param name="lowBrightness"></param>
+        [Obsolete("Method deprecated: use SetLedBlink(int index, int onDuration, int offDuration, float highBrightness, float lowBrightness)")]
+        public void SetLedBlink(uint index, uint onDuration = 200, uint offDuration = 200, float highBrightness = 1, float lowBrightness = 0)
+        {
+            if (index >= Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            pwmLeds[index].Stop();
+            pwmLeds[index].IsOn = false;
+            pwmLeds[index].StartBlink(onDuration, offDuration, highBrightness, lowBrightness);
+        }
+
+        /// <summary>
+        /// Starts a pulse animation on an individual LED
+        /// </summary>
+        /// <param name="index"></param>
+        /// <param name="pulseDuration"></param>
+        /// <param name="highBrightness"></param>
+        /// <param name="lowBrightness"></param>
+        [Obsolete("Method deprecated: use SetLedPulse(int index, int pulseDuration, float highBrightness, float lowBrightness)")]
+        public void SetLedPulse(uint index, uint pulseDuration = 600, float highBrightness = 1, float lowBrightness = 0.15F)
+        {
+            if (index >= Count)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            pwmLeds[index].StartPulse(pulseDuration, highBrightness, lowBrightness);
+        }
+
+        /// <summary>
+        /// Start the Blink animation which sets the brightness of the LED alternating between a low and high brightness setting, using the durations provided.
+        /// </summary>
+        /// <param name="onDuration">On duration.</param>
+        /// <param name="offDuration">Off duration.</param>
+        /// <param name="highBrightness">High brigtness.</param>
+        /// <param name="lowBrightness">Low brightness.</param>
+        [Obsolete("Method deprecated: use StartBlink(int onDuration, int offDuration, float highBrightness, float lowBrightness)")]
+        public void StartBlink(uint onDuration = 200, uint offDuration = 200, float highBrightness = 1, float lowBrightness = 0)
+        {
+            foreach (var pwmLed in pwmLeds)
+            {
+                pwmLed.StartBlink(onDuration, offDuration, highBrightness, lowBrightness);
+            }
+        }
+
+        /// <summary>
+        /// Start the Pulse animation which gradually alternates the brightness of the LED between a low and high brightness setting, using the durations provided.
+        /// <param name="pulseDuration">Pulse duration.</param>
+        /// <param name="highBrightness">High brigtness.</param>
+        /// <param name="lowBrightness">Low brightness.</param>
+        /// </summary>
+        [Obsolete("Method deprecated: use StartPulse(int pulseDuration, float highBrightness, float lowBrightness)")]
+        public void StartPulse(uint pulseDuration = 600, float highBrightness = 1, float lowBrightness = 0.15F)
+        {
+            if (highBrightness > 1 || highBrightness <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(highBrightness), "highBrightness must be > 0 and <= 1");
+            }
+            if (lowBrightness >= 1 || lowBrightness < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(lowBrightness), "lowBrightness must be >= 0 and < 1");
+            }
+            if (lowBrightness >= highBrightness)
+            {
+                throw new Exception("lowBrightness must be less than highbrightness");
+            }
+
+            foreach (var pwmLed in pwmLeds)
+            {
+                pwmLed.StartPulse(pulseDuration, highBrightness, lowBrightness);
+            }
+        }
     }
 }

--- a/Source/Meadow.Foundation.Core/Leds/RgbLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/RgbLed.cs
@@ -196,7 +196,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="onDuration"></param>
         /// <param name="offDuration"></param>
         [Obsolete("Method deprecated: use StartBlink(Colors color, int onDuration, int offDuration)")]
-        public void StartBlink(Colors color, uint onDuration = 200, uint offDuration = 200)
+        public void StartBlink(Colors color, uint onDuration, uint offDuration)
         {
             Stop();
 

--- a/Source/Meadow.Foundation.Core/Leds/RgbLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/RgbLed.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Meadow.Peripherals.Leds;
 using static Meadow.Peripherals.Leds.IRgbLed;
+using System;
 
 namespace Meadow.Foundation.Leds
 {
@@ -186,6 +187,25 @@ namespace Meadow.Foundation.Leds
                 SetColor(Colors.Black);
                 await Task.Delay((int)offDuration);
             }
+        }
+
+        /// <summary>
+        /// Starts the blink animation.
+        /// </summary>
+        /// <param name="color"></param>
+        /// <param name="onDuration"></param>
+        /// <param name="offDuration"></param>
+        [Obsolete("Method deprecated: use StartBlink(Colors color, int onDuration, int offDuration)")]
+        public void StartBlink(Colors color, uint onDuration = 200, uint offDuration = 200)
+        {
+            Stop();
+
+            animationTask = new Task(async () =>
+            {
+                cancellationTokenSource = new CancellationTokenSource();
+                await StartBlinkAsync(color, (int)onDuration, (int)offDuration, cancellationTokenSource.Token);
+            });
+            animationTask.Start();
         }
     }
 }

--- a/Source/Meadow.Foundation.Core/Leds/RgbPwmLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/RgbPwmLed.cs
@@ -328,7 +328,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="highBrightness"></param>
         /// <param name="lowBrightness"></param>
         [Obsolete("Method deprecated: use StartBlink(Color color, int onDuration, int offDuration, float highBrightness, float lowBrightness)")]
-        public void StartBlink(Color color, uint onDuration = 200, uint offDuration = 200, float highBrightness = 1f, float lowBrightness = 0f)
+        public void StartBlink(Color color, uint onDuration, uint offDuration, float highBrightness, float lowBrightness)
         {
             if (highBrightness > 1 || highBrightness <= 0)
             {
@@ -363,7 +363,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="highBrightness"></param>
         /// <param name="lowBrightness"></param>
         [Obsolete("Method deprecated: use StartPulse(Color color, int pulseDuration, float highBrightness, float lowBrightness)")]
-        public void StartPulse(Color color, uint pulseDuration = 600, float highBrightness = 1, float lowBrightness = 0.15F)
+        public void StartPulse(Color color, uint pulseDuration, float highBrightness, float lowBrightness)
         {
             if (highBrightness > 1 || highBrightness <= 0)
             {

--- a/Source/Meadow.Foundation.Core/Leds/RgbPwmLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/RgbPwmLed.cs
@@ -318,5 +318,76 @@ namespace Meadow.Foundation.Leds
                 await Task.Delay(intervalTime);
             }
         }
+
+        /// <summary>
+        /// Start the Blink animation which sets the brightness of the LED alternating between a low and high brightness setting, using the durations provided.
+        /// </summary>
+        /// <param name="color"></param>
+        /// <param name="onDuration"></param>
+        /// <param name="offDuration"></param>
+        /// <param name="highBrightness"></param>
+        /// <param name="lowBrightness"></param>
+        [Obsolete("Method deprecated: use StartBlink(Color, int onDuration, int offDuration, float highBrightness, float lowBrightness)")]
+        public void StartBlink(Color color, uint onDuration = 200, uint offDuration = 200, float highBrightness = 1f, float lowBrightness = 0f)
+        {
+            if (highBrightness > 1 || highBrightness <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(highBrightness), "onBrightness must be > 0 and <= 1");
+            }
+            if (lowBrightness >= 1 || lowBrightness < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(lowBrightness), "lowBrightness must be >= 0 and < 1");
+            }
+            if (lowBrightness >= highBrightness)
+            {
+                throw new Exception("offBrightness must be less than onBrightness");
+            }
+
+            Color = color;
+
+            Stop();
+
+            animationTask = new Task(async () =>
+            {
+                cancellationTokenSource = new CancellationTokenSource();
+                await StartBlinkAsync(color, (int)onDuration, (int)offDuration, highBrightness, lowBrightness, cancellationTokenSource.Token);
+            });
+            animationTask.Start();
+        }
+
+        /// <summary>
+        /// Start the Pulse animation which gradually alternates the brightness of the LED between a low and high brightness setting, using the durations provided.
+        /// </summary>
+        /// <param name="color"></param>
+        /// <param name="pulseDuration"></param>
+        /// <param name="highBrightness"></param>
+        /// <param name="lowBrightness"></param>
+        [Obsolete("Method deprecated: use StartPulse(Color color, int pulseDuration, float highBrightness, float lowBrightness)")]
+        public void StartPulse(Color color, uint pulseDuration = 600, float highBrightness = 1, float lowBrightness = 0.15F)
+        {
+            if (highBrightness > 1 || highBrightness <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(highBrightness), "onBrightness must be > 0 and <= 1");
+            }
+            if (lowBrightness >= 1 || lowBrightness < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(lowBrightness), "lowBrightness must be >= 0 and < 1");
+            }
+            if (lowBrightness >= highBrightness)
+            {
+                throw new Exception("offBrightness must be less than onBrightness");
+            }
+
+            Color = color;
+
+            Stop();
+
+            animationTask = new Task(async () =>
+            {
+                cancellationTokenSource = new CancellationTokenSource();
+                await StartPulseAsync(color, (int) pulseDuration, highBrightness, lowBrightness, cancellationTokenSource.Token);
+            });
+            animationTask.Start();
+        }
     }
 }

--- a/Source/Meadow.Foundation.Core/Leds/RgbPwmLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/RgbPwmLed.cs
@@ -327,7 +327,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="offDuration"></param>
         /// <param name="highBrightness"></param>
         /// <param name="lowBrightness"></param>
-        [Obsolete("Method deprecated: use StartBlink(Color, int onDuration, int offDuration, float highBrightness, float lowBrightness)")]
+        [Obsolete("Method deprecated: use StartBlink(Color color, int onDuration, int offDuration, float highBrightness, float lowBrightness)")]
         public void StartBlink(Color color, uint onDuration = 200, uint offDuration = 200, float highBrightness = 1f, float lowBrightness = 0f)
         {
             if (highBrightness > 1 || highBrightness <= 0)


### PR DESCRIPTION
To minimize API breaking changes over changing uint parameters to int in Meadow.Foundation.Core, added obsolete tags on old methods to deprecate them and remove them in future updates.