### PR TITLE
Meadow.Foundation drivers update to new Meadow hardware pattern

### DIFF
--- a/Source/Meadow.Foundation.Core/Communications/SerialTextFile.cs
+++ b/Source/Meadow.Foundation.Core/Communications/SerialTextFile.cs
@@ -80,7 +80,7 @@ namespace Meadow.Foundation.Communications
         /// <param name="dataBits">Data bits.</param>
         /// <param name="stopBits">Stop bits.</param>
         /// <param name="endOfLine">Text indicating the end of a line of text.</param>
-        public SerialTextFile(ISerialDevice device, SerialPortName port, int baudRate, Parity parity, int dataBits, StopBits stopBits,
+        public SerialTextFile(ISerialController device, SerialPortName port, int baudRate, Parity parity, int dataBits, StopBits stopBits,
             string endOfLine)
         {
             serialPort = device.CreateSerialPort(port, baudRate, dataBits, parity, stopBits);

--- a/Source/Meadow.Foundation.Core/Communications/SerialTextFile.cs
+++ b/Source/Meadow.Foundation.Core/Communications/SerialTextFile.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing.Text;
 using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Communications
@@ -79,7 +80,7 @@ namespace Meadow.Foundation.Communications
         /// <param name="dataBits">Data bits.</param>
         /// <param name="stopBits">Stop bits.</param>
         /// <param name="endOfLine">Text indicating the end of a line of text.</param>
-        public SerialTextFile(IIODevice device, SerialPortName port, int baudRate, Parity parity, int dataBits, StopBits stopBits,
+        public SerialTextFile(ISerialDevice device, SerialPortName port, int baudRate, Parity parity, int dataBits, StopBits stopBits,
             string endOfLine)
         {
             serialPort = device.CreateSerialPort(port, baudRate, dataBits, parity, stopBits);

--- a/Source/Meadow.Foundation.Core/Leds/Led.cs
+++ b/Source/Meadow.Foundation.Core/Leds/Led.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 using Meadow.Peripherals.Leds;
 using System;
@@ -39,7 +40,7 @@ namespace Meadow.Foundation.Leds
 		/// Creates a LED through a pin directly from the Digital IO of the board
 		/// </summary>
 		/// <param name="pin"></param>
-		public Led(IIODevice device, IPin pin) :
+		public Led(IDigitalOutputDevice device, IPin pin) :
 			this(device.CreateDigitalOutputPort(pin, false))
 		{ }
 

--- a/Source/Meadow.Foundation.Core/Leds/Led.cs
+++ b/Source/Meadow.Foundation.Core/Leds/Led.cs
@@ -1,4 +1,4 @@
-using Meadow.Devices;
+﻿using Meadow.Devices;
 using Meadow.Hardware;
 using Meadow.Peripherals.Leds;
 using System;
@@ -40,7 +40,7 @@ namespace Meadow.Foundation.Leds
 		/// Creates a LED through a pin directly from the Digital IO of the board
 		/// </summary>
 		/// <param name="pin"></param>
-		public Led(IDigitalOutputDevice device, IPin pin) :
+		public Led(IDigitalOutputController device, IPin pin) :
 			this(device.CreateDigitalOutputPort(pin, false))
 		{ }
 

--- a/Source/Meadow.Foundation.Core/Leds/LedBarGraph.cs
+++ b/Source/Meadow.Foundation.Core/Leds/LedBarGraph.cs
@@ -29,7 +29,7 @@ namespace Meadow.Foundation.Leds
         /// <summary>
         /// Create an LedBarGraph instance from an array of IPins
         /// </summary>
-        public LedBarGraph(IDigitalOutputDevice device, IPin[] pins)
+        public LedBarGraph(IDigitalOutputController device, IPin[] pins)
         {
             leds = new Led[pins.Length];
 

--- a/Source/Meadow.Foundation.Core/Leds/LedBarGraph.cs
+++ b/Source/Meadow.Foundation.Core/Leds/LedBarGraph.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 
 namespace Meadow.Foundation.Leds
@@ -28,7 +29,7 @@ namespace Meadow.Foundation.Leds
         /// <summary>
         /// Create an LedBarGraph instance from an array of IPins
         /// </summary>
-        public LedBarGraph(IIODevice device, IPin[] pins)
+        public LedBarGraph(IDigitalOutputDevice device, IPin[] pins)
         {
             leds = new Led[pins.Length];
 

--- a/Source/Meadow.Foundation.Core/Leds/PwmLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/PwmLed.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Meadow.Devices;
 using Meadow.Hardware;
 using Meadow.Peripherals.Leds;
 
@@ -58,7 +59,7 @@ namespace Meadow.Foundation.Leds
         /// hooked to ground or High. Typically used for RGB Leds which can have
         /// either a common cathode, or common anode. But can also enable an LED
         /// to be reversed by inverting the PWM signal.</param>
-        public PwmLed(IIODevice device, IPin pin,
+        public PwmLed(IPwmOutputDevice device, IPin pin,
             float forwardVoltage, CircuitTerminationType terminationType = CircuitTerminationType.CommonGround) : 
             this (device.CreatePwmPort(pin), forwardVoltage, terminationType) { }
 

--- a/Source/Meadow.Foundation.Core/Leds/PwmLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/PwmLed.cs
@@ -59,7 +59,7 @@ namespace Meadow.Foundation.Leds
         /// hooked to ground or High. Typically used for RGB Leds which can have
         /// either a common cathode, or common anode. But can also enable an LED
         /// to be reversed by inverting the PWM signal.</param>
-        public PwmLed(IPwmOutputDevice device, IPin pin,
+        public PwmLed(IPwmOutputController device, IPin pin,
             float forwardVoltage, CircuitTerminationType terminationType = CircuitTerminationType.CommonGround) : 
             this (device.CreatePwmPort(pin), forwardVoltage, terminationType) { }
 

--- a/Source/Meadow.Foundation.Core/Leds/PwmLedBarGraph.cs
+++ b/Source/Meadow.Foundation.Core/Leds/PwmLedBarGraph.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 
 namespace Meadow.Foundation.Leds
@@ -28,7 +29,7 @@ namespace Meadow.Foundation.Leds
         /// <summary>
         /// Create an LedBarGraph instance from an array of IPwnPin and a forwardVoltage for all LEDs in the bar graph
         /// </summary>
-        public PwmLedBarGraph(IIODevice device, IPin[] pins, float forwardVoltage)
+        public PwmLedBarGraph(IPwmOutputDevice device, IPin[] pins, float forwardVoltage)
         {
             pwmLeds = new PwmLed[pins.Length];
 

--- a/Source/Meadow.Foundation.Core/Leds/PwmLedBarGraph.cs
+++ b/Source/Meadow.Foundation.Core/Leds/PwmLedBarGraph.cs
@@ -29,7 +29,7 @@ namespace Meadow.Foundation.Leds
         /// <summary>
         /// Create an LedBarGraph instance from an array of IPwnPin and a forwardVoltage for all LEDs in the bar graph
         /// </summary>
-        public PwmLedBarGraph(IPwmOutputDevice device, IPin[] pins, float forwardVoltage)
+        public PwmLedBarGraph(IPwmOutputController device, IPin[] pins, float forwardVoltage)
         {
             pwmLeds = new PwmLed[pins.Length];
 

--- a/Source/Meadow.Foundation.Core/Leds/RgbLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/RgbLed.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Meadow.Peripherals.Leds;
 using static Meadow.Peripherals.Leds.IRgbLed;
 using System;
+using Meadow.Devices;
 
 namespace Meadow.Foundation.Leds
 {
@@ -61,7 +62,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="bluePin">Blue Pin</param>
         /// <param name="commonType">Is Common Cathode</param>
         public RgbLed(
-            IIODevice device, 
+            IDigitalOutputDevice device, 
             IPin redPin, 
             IPin greenPin, 
             IPin bluePin, 

--- a/Source/Meadow.Foundation.Core/Leds/RgbLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/RgbLed.cs
@@ -62,7 +62,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="bluePin">Blue Pin</param>
         /// <param name="commonType">Is Common Cathode</param>
         public RgbLed(
-            IDigitalOutputDevice device, 
+            IDigitalOutputController device, 
             IPin redPin, 
             IPin greenPin, 
             IPin bluePin, 

--- a/Source/Meadow.Foundation.Core/Leds/RgbPwmLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/RgbPwmLed.cs
@@ -94,7 +94,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="greenLedForwardVoltage"></param>
         /// <param name="blueLedForwardVoltage"></param>
         /// <param name="isCommonCathode"></param>
-        public RgbPwmLed(IPwmOutputDevice device,
+        public RgbPwmLed(IPwmOutputController device,
             IPin redPwmPin, IPin greenPwmPin, IPin bluePwmPin,
             float redLedForwardVoltage = TypicalForwardVoltage.ResistorLimited,
             float greenLedForwardVoltage = TypicalForwardVoltage.ResistorLimited,

--- a/Source/Meadow.Foundation.Core/Leds/RgbPwmLed.cs
+++ b/Source/Meadow.Foundation.Core/Leds/RgbPwmLed.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using Meadow.Hardware;
 using System.Threading.Tasks;
 using static Meadow.Peripherals.Leds.IRgbLed;
+using Meadow.Devices;
 
 namespace Meadow.Foundation.Leds
 {
@@ -93,7 +94,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="greenLedForwardVoltage"></param>
         /// <param name="blueLedForwardVoltage"></param>
         /// <param name="isCommonCathode"></param>
-        public RgbPwmLed(IIODevice device,
+        public RgbPwmLed(IPwmOutputDevice device,
             IPin redPwmPin, IPin greenPwmPin, IPin bluePwmPin,
             float redLedForwardVoltage = TypicalForwardVoltage.ResistorLimited,
             float greenLedForwardVoltage = TypicalForwardVoltage.ResistorLimited,

--- a/Source/Meadow.Foundation.Core/Motors/HBridgeMotor.cs
+++ b/Source/Meadow.Foundation.Core/Motors/HBridgeMotor.cs
@@ -72,7 +72,7 @@ namespace Meadow.Foundation.Motors
         /// </summary>
         public float MotorCalibrationMultiplier { get; set; } = 1;
 
-        public HBridgeMotor(IPwmOutputDevice device, IPin a1Pin, IPin a2Pin, IDigitalOutputPort enablePin, float pwmFrequency = 1600) :
+        public HBridgeMotor(IPwmOutputController device, IPin a1Pin, IPin a2Pin, IDigitalOutputPort enablePin, float pwmFrequency = 1600) :
             this(device.CreatePwmPort(a1Pin), device.CreatePwmPort(a2Pin), enablePin, pwmFrequency)
         { }
 

--- a/Source/Meadow.Foundation.Core/Motors/HBridgeMotor.cs
+++ b/Source/Meadow.Foundation.Core/Motors/HBridgeMotor.cs
@@ -1,7 +1,7 @@
-﻿using Meadow.Devices;
+﻿using System;
+using Meadow.Devices;
 using Meadow.Hardware;
 using Meadow.Peripherals.Motors;
-using System;
 
 namespace Meadow.Foundation.Motors
 {
@@ -72,6 +72,13 @@ namespace Meadow.Foundation.Motors
         /// </summary>
         public float MotorCalibrationMultiplier { get; set; } = 1;
 
+        // TODO: this convenience constructor is weird. we create the PWM but
+        // not the digital output port. i think if we're going to have a convenience
+        // constructor it should be:
+        public HBridgeMotor(IMeadowDevice device, IPin a1Pin, IPin a2Pin, IPin enablePin, float pwmFrequency = 1600) :
+            this(device.CreatePwmPort(a1Pin), device.CreatePwmPort(a2Pin), device.CreateDigitalOutputPort(enablePin), pwmFrequency)
+        { }
+        // and we should [obsolete] or delete this one:
         public HBridgeMotor(IPwmOutputController device, IPin a1Pin, IPin a2Pin, IDigitalOutputPort enablePin, float pwmFrequency = 1600) :
             this(device.CreatePwmPort(a1Pin), device.CreatePwmPort(a2Pin), enablePin, pwmFrequency)
         { }

--- a/Source/Meadow.Foundation.Core/Motors/HBridgeMotor.cs
+++ b/Source/Meadow.Foundation.Core/Motors/HBridgeMotor.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using Meadow.Peripherals.Motors;
 using System;
 
@@ -71,7 +72,7 @@ namespace Meadow.Foundation.Motors
         /// </summary>
         public float MotorCalibrationMultiplier { get; set; } = 1;
 
-        public HBridgeMotor(IIODevice device, IPin a1Pin, IPin a2Pin, IDigitalOutputPort enablePin, float pwmFrequency = 1600) :
+        public HBridgeMotor(IPwmOutputDevice device, IPin a1Pin, IPin a2Pin, IDigitalOutputPort enablePin, float pwmFrequency = 1600) :
             this(device.CreatePwmPort(a1Pin), device.CreatePwmPort(a2Pin), enablePin, pwmFrequency)
         { }
 

--- a/Source/Meadow.Foundation.Core/Relays/Relay.cs
+++ b/Source/Meadow.Foundation.Core/Relays/Relay.cs
@@ -39,7 +39,7 @@ namespace Meadow.Foundation.Relays
         /// </summary>
         /// <param name="pin"></param>
         /// <param name="type"></param>
-        public Relay(IDigitalOutputDevice device, IPin pin, RelayType type = RelayType.NormallyOpen) :
+        public Relay(IDigitalOutputController device, IPin pin, RelayType type = RelayType.NormallyOpen) :
             this(device.CreateDigitalOutputPort(pin), type) { }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Core/Relays/Relay.cs
+++ b/Source/Meadow.Foundation.Core/Relays/Relay.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 using Meadow.Peripherals.Relays;
 
@@ -38,7 +39,7 @@ namespace Meadow.Foundation.Relays
         /// </summary>
         /// <param name="pin"></param>
         /// <param name="type"></param>
-        public Relay(IIODevice device, IPin pin, RelayType type = RelayType.NormallyOpen) :
+        public Relay(IDigitalOutputDevice device, IPin pin, RelayType type = RelayType.NormallyOpen) :
             this(device.CreateDigitalOutputPort(pin), type) { }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Core/Sensors/Buttons/PushButton.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Buttons/PushButton.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Buttons;
 using System;
 
@@ -141,7 +142,7 @@ namespace Meadow.Foundation.Sensors.Buttons
         /// <param name="device"></param>
         /// <param name="inputPin"></param>
         /// <param name="resistorMode"></param>
-        public PushButton(IIODevice device, IPin inputPin, ResistorMode resistorMode = ResistorMode.InternalPullUp) 
+        public PushButton(IDigitalInputDevice device, IPin inputPin, ResistorMode resistorMode = ResistorMode.InternalPullUp) 
             : this(device.CreateDigitalInputPort(inputPin, InterruptMode.EdgeBoth, resistorMode, 50, 25)) { }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Core/Sensors/Buttons/PushButton.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Buttons/PushButton.cs
@@ -142,7 +142,7 @@ namespace Meadow.Foundation.Sensors.Buttons
         /// <param name="device"></param>
         /// <param name="inputPin"></param>
         /// <param name="resistorMode"></param>
-        public PushButton(IDigitalInputDevice device, IPin inputPin, ResistorMode resistorMode = ResistorMode.InternalPullUp) 
+        public PushButton(IDigitalInputController device, IPin inputPin, ResistorMode resistorMode = ResistorMode.InternalPullUp) 
             : this(device.CreateDigitalInputPort(inputPin, InterruptMode.EdgeBoth, resistorMode, 50, 25)) { }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Core/Sensors/Environmental/AnalogWaterLevel.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Environmental/AnalogWaterLevel.cs
@@ -67,7 +67,7 @@ namespace Meadow.Foundation.Sensors.Environmental
         /// <param name="sensorType">Type of sensor attached to the analog port.</param>
         /// <param name="calibration">Calibration for the analog temperature sensor. Only used if sensorType is set to Custom.</param>
         public AnalogWaterLevel(
-            IAnalogInputDevice device,
+            IAnalogInputController device,
             IPin analogPin,
             Calibration calibration = null
             ) : this(device.CreateAnalogInputPort(analogPin), calibration)

--- a/Source/Meadow.Foundation.Core/Sensors/Environmental/AnalogWaterLevel.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Environmental/AnalogWaterLevel.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 using System.Threading.Tasks;
 
@@ -66,7 +67,7 @@ namespace Meadow.Foundation.Sensors.Environmental
         /// <param name="sensorType">Type of sensor attached to the analog port.</param>
         /// <param name="calibration">Calibration for the analog temperature sensor. Only used if sensorType is set to Custom.</param>
         public AnalogWaterLevel(
-            IIODevice device,
+            IAnalogInputDevice device,
             IPin analogPin,
             Calibration calibration = null
             ) : this(device.CreateAnalogInputPort(analogPin), calibration)

--- a/Source/Meadow.Foundation.Core/Sensors/HallEffect/DigitalTachometer.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/HallEffect/DigitalTachometer.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using Meadow.Peripherals.Sensors;
 using System;
 using System.Diagnostics;
@@ -52,7 +53,7 @@ namespace Meadow.Foundation.Sensors.HallEffect
         /// <param name="type"></param>
         /// <param name="numberOfMagnets"></param>
         /// <param name="rpmChangeNotificationThreshold"></param>
-        public LinearHallEffectTachometer(IIODevice device, IPin inputPin, CircuitTerminationType type = CircuitTerminationType.CommonGround,
+        public LinearHallEffectTachometer(IDigitalInputDevice device, IPin inputPin, CircuitTerminationType type = CircuitTerminationType.CommonGround,
             ushort numberOfMagnets = 2, float rpmChangeNotificationThreshold = 1.0F) :
             this(device.CreateDigitalInputPort(inputPin), type, numberOfMagnets, rpmChangeNotificationThreshold)
         {

--- a/Source/Meadow.Foundation.Core/Sensors/HallEffect/DigitalTachometer.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/HallEffect/DigitalTachometer.cs
@@ -53,7 +53,7 @@ namespace Meadow.Foundation.Sensors.HallEffect
         /// <param name="type"></param>
         /// <param name="numberOfMagnets"></param>
         /// <param name="rpmChangeNotificationThreshold"></param>
-        public LinearHallEffectTachometer(IDigitalInputDevice device, IPin inputPin, CircuitTerminationType type = CircuitTerminationType.CommonGround,
+        public LinearHallEffectTachometer(IDigitalInputController device, IPin inputPin, CircuitTerminationType type = CircuitTerminationType.CommonGround,
             ushort numberOfMagnets = 2, float rpmChangeNotificationThreshold = 1.0F) :
             this(device.CreateDigitalInputPort(inputPin), type, numberOfMagnets, rpmChangeNotificationThreshold)
         {

--- a/Source/Meadow.Foundation.Core/Sensors/Hid/AnalogJoystick.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Hid/AnalogJoystick.cs
@@ -58,7 +58,7 @@ namespace Meadow.Foundation.Sensors.Hid
 
         #region Constructors
 
-        public AnalogJoystick(IAnalogInputDevice device, IPin horizontalPin, IPin verticalPin, JoystickCalibration calibration = null, bool isInverted = false) :
+        public AnalogJoystick(IAnalogInputController device, IPin horizontalPin, IPin verticalPin, JoystickCalibration calibration = null, bool isInverted = false) :
             this(device.CreateAnalogInputPort(horizontalPin), device.CreateAnalogInputPort(verticalPin), calibration, isInverted)
         { }
 

--- a/Source/Meadow.Foundation.Core/Sensors/Hid/AnalogJoystick.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Hid/AnalogJoystick.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Hid;
 using System;
 using System.Threading.Tasks;
@@ -57,7 +58,7 @@ namespace Meadow.Foundation.Sensors.Hid
 
         #region Constructors
 
-        public AnalogJoystick(IIODevice device, IPin horizontalPin, IPin verticalPin, JoystickCalibration calibration = null, bool isInverted = false) :
+        public AnalogJoystick(IAnalogInputDevice device, IPin horizontalPin, IPin verticalPin, JoystickCalibration calibration = null, bool isInverted = false) :
             this(device.CreateAnalogInputPort(horizontalPin), device.CreateAnalogInputPort(verticalPin), calibration, isInverted)
         { }
 

--- a/Source/Meadow.Foundation.Core/Sensors/Rotary/RotaryEncoder.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Rotary/RotaryEncoder.cs
@@ -58,7 +58,7 @@ namespace Meadow.Foundation.Sensors.Rotary
         /// <param name="device"></param>
         /// <param name="aPhasePin"></param>
         /// <param name="bPhasePin"></param>
-        public RotaryEncoder(IIODevice device, IPin aPhasePin, IPin bPhasePin) :
+        public RotaryEncoder(IDigitalInputDevice device, IPin aPhasePin, IPin bPhasePin) :
             this(device.CreateDigitalInputPort(aPhasePin, InterruptMode.EdgeBoth, ResistorMode.InternalPullDown, 0, 0.1),
                  device.CreateDigitalInputPort(bPhasePin, InterruptMode.EdgeBoth, ResistorMode.InternalPullDown, 0, 0.1))
         { }

--- a/Source/Meadow.Foundation.Core/Sensors/Rotary/RotaryEncoder.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Rotary/RotaryEncoder.cs
@@ -58,7 +58,7 @@ namespace Meadow.Foundation.Sensors.Rotary
         /// <param name="device"></param>
         /// <param name="aPhasePin"></param>
         /// <param name="bPhasePin"></param>
-        public RotaryEncoder(IDigitalInputDevice device, IPin aPhasePin, IPin bPhasePin) :
+        public RotaryEncoder(IDigitalInputController device, IPin aPhasePin, IPin bPhasePin) :
             this(device.CreateDigitalInputPort(aPhasePin, InterruptMode.EdgeBoth, ResistorMode.InternalPullDown, 0, 0.1),
                  device.CreateDigitalInputPort(bPhasePin, InterruptMode.EdgeBoth, ResistorMode.InternalPullDown, 0, 0.1))
         { }

--- a/Source/Meadow.Foundation.Core/Sensors/Rotary/RotaryEncoderWithButton.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Rotary/RotaryEncoderWithButton.cs
@@ -44,7 +44,7 @@ namespace Meadow.Foundation.Sensors.Rotary
         /// <param name="buttonPin"></param>
         /// <param name="resistor"></param>
         /// <param name="debounceDuration"></param>
-        public RotaryEncoderWithButton(IIODevice device, IPin aPhasePin, IPin bPhasePin, IPin buttonPin, ResistorMode buttonResistorMode = ResistorMode.InternalPullDown)
+        public RotaryEncoderWithButton(IDigitalInputDevice device, IPin aPhasePin, IPin bPhasePin, IPin buttonPin, ResistorMode buttonResistorMode = ResistorMode.InternalPullDown)
             : base(device, aPhasePin, bPhasePin)
         {
             _button = new PushButton(device, buttonPin, buttonResistorMode);

--- a/Source/Meadow.Foundation.Core/Sensors/Rotary/RotaryEncoderWithButton.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Rotary/RotaryEncoderWithButton.cs
@@ -44,7 +44,7 @@ namespace Meadow.Foundation.Sensors.Rotary
         /// <param name="buttonPin"></param>
         /// <param name="resistor"></param>
         /// <param name="debounceDuration"></param>
-        public RotaryEncoderWithButton(IDigitalInputDevice device, IPin aPhasePin, IPin bPhasePin, IPin buttonPin, ResistorMode buttonResistorMode = ResistorMode.InternalPullDown)
+        public RotaryEncoderWithButton(IDigitalInputController device, IPin aPhasePin, IPin bPhasePin, IPin buttonPin, ResistorMode buttonResistorMode = ResistorMode.InternalPullDown)
             : base(device, aPhasePin, bPhasePin)
         {
             _button = new PushButton(device, buttonPin, buttonResistorMode);

--- a/Source/Meadow.Foundation.Core/Sensors/Switches/DipSwitch.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Switches/DipSwitch.cs
@@ -45,7 +45,7 @@ namespace Meadow.Foundation.Sensors.Switches
         /// <param name="resistorMode"></param>
         /// <param name="debounceDuration"></param>
         /// <param name="glitchFilterCycleCount"></param>
-        public DipSwitch(IIODevice device, IPin[] switchPins, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0)
+        public DipSwitch(IDigitalInputDevice device, IPin[] switchPins, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0)
         {
             Switches = new ISwitch[switchPins.Length];
 

--- a/Source/Meadow.Foundation.Core/Sensors/Switches/DipSwitch.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Switches/DipSwitch.cs
@@ -45,7 +45,7 @@ namespace Meadow.Foundation.Sensors.Switches
         /// <param name="resistorMode"></param>
         /// <param name="debounceDuration"></param>
         /// <param name="glitchFilterCycleCount"></param>
-        public DipSwitch(IDigitalInputDevice device, IPin[] switchPins, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0)
+        public DipSwitch(IDigitalInputController device, IPin[] switchPins, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0)
         {
             Switches = new ISwitch[switchPins.Length];
 

--- a/Source/Meadow.Foundation.Core/Sensors/Switches/SpdtSwitch.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Switches/SpdtSwitch.cs
@@ -1,4 +1,4 @@
-using Meadow.Hardware;
+﻿using Meadow.Hardware;
 using Meadow.Peripherals.Sensors;
 using Meadow.Peripherals.Switches;
 using System;
@@ -47,7 +47,7 @@ namespace Meadow.Foundation.Sensors.Switches
         /// <param name="resistorMode"></param>
         /// <param name="debounceDuration"></param>
         /// <param name="glitchFilterCycleCount"></param>
-        public SpdtSwitch(IDigitalInputDevice device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) :
+        public SpdtSwitch(IDigitalInputController device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) :
             this (device.CreateDigitalInputPort(pin, interruptMode, resistorMode, debounceDuration, glitchFilterCycleCount)) {}
 
         /// <summary>

--- a/Source/Meadow.Foundation.Core/Sensors/Switches/SpdtSwitch.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Switches/SpdtSwitch.cs
@@ -47,7 +47,7 @@ namespace Meadow.Foundation.Sensors.Switches
         /// <param name="resistorMode"></param>
         /// <param name="debounceDuration"></param>
         /// <param name="glitchFilterCycleCount"></param>
-        public SpdtSwitch(IIODevice device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) :
+        public SpdtSwitch(IDigitalInputDevice device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) :
             this (device.CreateDigitalInputPort(pin, interruptMode, resistorMode, debounceDuration, glitchFilterCycleCount)) {}
 
         /// <summary>

--- a/Source/Meadow.Foundation.Core/Sensors/Switches/SpstSwitch.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Switches/SpstSwitch.cs
@@ -50,7 +50,7 @@ namespace Meadow.Foundation.Sensors.Switches
         /// <param name="resistorMode"></param>
         /// <param name="debounceDuration"></param>
         /// <param name="glitchFilterCycleCount"></param>
-        public SpstSwitch(IIODevice device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) :
+        public SpstSwitch(IDigitalInputDevice device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) :
             this(device.CreateDigitalInputPort(pin, interruptMode, resistorMode, debounceDuration, glitchFilterCycleCount)) { }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Core/Sensors/Switches/SpstSwitch.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Switches/SpstSwitch.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors;
 using Meadow.Peripherals.Switches;
@@ -50,7 +50,7 @@ namespace Meadow.Foundation.Sensors.Switches
         /// <param name="resistorMode"></param>
         /// <param name="debounceDuration"></param>
         /// <param name="glitchFilterCycleCount"></param>
-        public SpstSwitch(IDigitalInputDevice device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) :
+        public SpstSwitch(IDigitalInputController device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) :
             this(device.CreateDigitalInputPort(pin, interruptMode, resistorMode, debounceDuration, glitchFilterCycleCount)) { }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Core/Sensors/Temperature/AnalogTemperatureSensor.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Temperature/AnalogTemperatureSensor.cs
@@ -134,7 +134,7 @@ namespace Meadow.Foundation.Sensors.Temperature
         /// <param name="sensorType">Type of sensor attached to the analog port.</param>
         /// <param name="calibration">Calibration for the analog temperature sensor. Only used if sensorType is set to Custom.</param>
         public AnalogTemperature(
-            IAnalogInputDevice device,
+            IAnalogInputController device,
             IPin analogPin,
             KnownSensorType sensorType,
             Calibration calibration = null

--- a/Source/Meadow.Foundation.Core/Sensors/Temperature/AnalogTemperatureSensor.cs
+++ b/Source/Meadow.Foundation.Core/Sensors/Temperature/AnalogTemperatureSensor.cs
@@ -134,7 +134,7 @@ namespace Meadow.Foundation.Sensors.Temperature
         /// <param name="sensorType">Type of sensor attached to the analog port.</param>
         /// <param name="calibration">Calibration for the analog temperature sensor. Only used if sensorType is set to Custom.</param>
         public AnalogTemperature(
-            IIODevice device,
+            IAnalogInputDevice device,
             IPin analogPin,
             KnownSensorType sensorType,
             Calibration calibration = null

--- a/Source/Meadow.Foundation.Core/Speakers/PiezoSpeaker.cs
+++ b/Source/Meadow.Foundation.Core/Speakers/PiezoSpeaker.cs
@@ -20,7 +20,7 @@ namespace Meadow.Foundation.Audio
         /// Create a new PiezoSpeaker instance
         /// </summary>
         /// <param name="pin">PWM Pin connected to the PiezoSpeaker</param>
-        public PiezoSpeaker(IIODevice device, IPin pin, float frequency = 100, float dutyCycle = 0) :
+        public PiezoSpeaker(IPwmOutputDevice device, IPin pin, float frequency = 100, float dutyCycle = 0) :
             this (device.CreatePwmPort(pin, frequency, dutyCycle)) { }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Core/Speakers/PiezoSpeaker.cs
+++ b/Source/Meadow.Foundation.Core/Speakers/PiezoSpeaker.cs
@@ -20,7 +20,7 @@ namespace Meadow.Foundation.Audio
         /// Create a new PiezoSpeaker instance
         /// </summary>
         /// <param name="pin">PWM Pin connected to the PiezoSpeaker</param>
-        public PiezoSpeaker(IPwmOutputDevice device, IPin pin, float frequency = 100, float dutyCycle = 0) :
+        public PiezoSpeaker(IPwmOutputController device, IPin pin, float frequency = 100, float dutyCycle = 0) :
             this (device.CreatePwmPort(pin, frequency, dutyCycle)) { }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Peripherals/Audio.Mp3.Yx5300/Driver/Audio.Mp3.Yx5300/Yx5300.cs
+++ b/Source/Meadow.Foundation.Peripherals/Audio.Mp3.Yx5300/Driver/Audio.Mp3.Yx5300/Yx5300.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Audio.Mp3
@@ -75,7 +76,7 @@ namespace Meadow.Foundation.Audio.Mp3
             Thread.Sleep(500);
         }
 
-        public Yx5300(IIODevice device, SerialPortName serialPortName)
+        public Yx5300(IMeadowDevice device, SerialPortName serialPortName)
             : this(device.CreateSerialPort(
                 serialPortName))
         { }

--- a/Source/Meadow.Foundation.Peripherals/Audio.Radio.Tea5767/Driver/Audio.Radio.Tea5767/Tea5767.cs
+++ b/Source/Meadow.Foundation.Peripherals/Audio.Radio.Tea5767/Driver/Audio.Radio.Tea5767/Tea5767.cs
@@ -6,13 +6,10 @@ namespace Meadow.Foundation.Audio.Radio
 {
     public class Tea5767
     {
-        
         /// <summary>
         ///     TEA5767 radio.
         /// </summary>
         private readonly II2cPeripheral i2cPeripheral;
-
-        
 
         const byte TEA5767_ADDRESS = 0x60;
         static byte FIRST_DATA = 0;
@@ -55,12 +52,6 @@ namespace Meadow.Foundation.Audio.Radio
 
         public bool IsMuted { get; set; }
 
-        
-
-        
-
-        
-
         /// <summary>
         ///     Create a new TEA5767 object using the default parameters
         /// </summary>
@@ -71,10 +62,6 @@ namespace Meadow.Foundation.Audio.Radio
 
             InitTEA5767();
         }
-
-        
-
-        
 
         void InitTEA5767()
         {
@@ -469,7 +456,5 @@ namespace Meadow.Foundation.Audio.Radio
             transmissionData[FOURTH_DATA] &= 253;
             TransmitData();
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Displays.Lcd.CharacterDisplay/Driver/Displays.Lcd.CharacterDisplay/CharacterDisplay.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Lcd.CharacterDisplay/Driver/Displays.Lcd.CharacterDisplay/CharacterDisplay.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using Meadow.Peripherals.Displays;
 
 namespace Meadow.Foundation.Displays.Lcd
@@ -10,7 +11,7 @@ namespace Meadow.Foundation.Displays.Lcd
         public TextDisplayConfig DisplayConfig => characterDisplay?.DisplayConfig;
 
         public CharacterDisplay(
-            IIODevice device,
+            IMeadowDevice device,
             IPin pinRS,
             IPin pinE,
             IPin pinD4,
@@ -35,7 +36,7 @@ namespace Meadow.Foundation.Displays.Lcd
         }
 
         public CharacterDisplay(
-            IIODevice device,
+            IMeadowDevice device,
             IPin pinV0,
             IPin pinRS,
             IPin pinE,

--- a/Source/Meadow.Foundation.Peripherals/Displays.Lcd.CharacterDisplay/Driver/Displays.Lcd.CharacterDisplay/GpioCharacterDisplay.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Lcd.CharacterDisplay/Driver/Displays.Lcd.CharacterDisplay/GpioCharacterDisplay.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using Meadow.Peripherals.Displays;
 using System;
 using System.Threading;
@@ -34,7 +35,7 @@ namespace Meadow.Foundation.Displays.Lcd
         public TextDisplayConfig DisplayConfig { get; protected set; }
 
         public GpioCharacterDisplay(
-            IIODevice device,
+            IMeadowDevice device,
             IPin pinRS,
             IPin pinE,
             IPin pinD4,
@@ -74,7 +75,7 @@ namespace Meadow.Foundation.Displays.Lcd
         }
 
         public GpioCharacterDisplay(
-            IIODevice device,
+            IMeadowDevice device,
             IPin pinV0,
             IPin pinRS,
             IPin pinE,

--- a/Source/Meadow.Foundation.Peripherals/Displays.Led.FourDigitSevenSegment/Driver/Displays.Led.FourDigitSevenSegment/FourDigitSevenSegment.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Led.FourDigitSevenSegment/Driver/Displays.Led.FourDigitSevenSegment/FourDigitSevenSegment.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.Led
@@ -31,7 +32,7 @@ namespace Meadow.Foundation.Displays.Led
         /// <param name="pinDecimal"></param>
         /// <param name="isCommonCathode"></param>
         public FourDigitSevenSegment(
-            IIODevice device, 
+            IMeadowDevice device, 
             IPin pinDigit1, IPin pinDigit2,
             IPin pinDigit3, IPin pinDigit4,
             IPin pinA, IPin pinB,

--- a/Source/Meadow.Foundation.Peripherals/Displays.Led.SevenSegment/Driver/Displays.Led.SevenSegment/SevenSegment.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Led.SevenSegment/Driver/Displays.Led.SevenSegment/SevenSegment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.Led
@@ -8,7 +9,6 @@ namespace Meadow.Foundation.Displays.Led
     /// </summary>
     public class SevenSegment
     {
-        
         /// <summary>
         /// Valid Characters to display
         /// </summary>
@@ -33,10 +33,6 @@ namespace Meadow.Foundation.Displays.Led
             Blank,
             count
         }
-
-        
-
-        
 
         private readonly IDigitalOutputPort _portA;
         private readonly IDigitalOutputPort _portB;
@@ -70,10 +66,6 @@ namespace Meadow.Foundation.Displays.Led
              {0, 0, 0, 0, 0, 0, 0}, //blank
         };
 
-        
-
-        
-
         /// <summary>
         /// Creates a SevenSegment connected to the especified IPins to a IODevice
         /// </summary>
@@ -88,7 +80,7 @@ namespace Meadow.Foundation.Displays.Led
         /// <param name="pinDecimal"></param>
         /// <param name="isCommonCathode"></param>
         public SevenSegment(
-            IIODevice device, 
+            IMeadowDevice device, 
             IPin pinA, IPin pinB,
             IPin pinC, IPin pinD,
             IPin pinE, IPin pinF,
@@ -134,10 +126,6 @@ namespace Meadow.Foundation.Displays.Led
 
             _isCommonCathode = isCommonCathode;
         }
-
-        
-
-        
 
         /// <summary>
         /// Displays the especified character
@@ -189,7 +177,5 @@ namespace Meadow.Foundation.Displays.Led
 
             SetDisplay(charType, showDecimal);
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Displays.Led.SevenSegment/Driver/Displays.Led.SevenSegment/SevenSegment.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Led.SevenSegment/Driver/Displays.Led.SevenSegment/SevenSegment.cs
@@ -80,7 +80,7 @@ namespace Meadow.Foundation.Displays.Led
         /// <param name="pinDecimal"></param>
         /// <param name="isCommonCathode"></param>
         public SevenSegment(
-            IMeadowDevice device, 
+            IDigitalOutputController device, 
             IPin pinA, IPin pinB,
             IPin pinC, IPin pinD,
             IPin pinE, IPin pinF,

--- a/Source/Meadow.Foundation.Peripherals/Displays.Max7219/Driver/Displays.Max7219/Max7219.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Max7219/Driver/Displays.Max7219/Max7219.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays
@@ -58,10 +59,6 @@ namespace Meadow.Foundation.Displays
 
         private readonly byte DECIMAL = 0b10000000;
 
-        
-
-        
-
         public enum Max7219Type
         {
             Character, 
@@ -109,10 +106,6 @@ namespace Meadow.Foundation.Displays
             DisplayTest = 0x0F
         }
 
-        
-
-        
-
         public Max7219(ISpiBus spiBus, IDigitalOutputPort csPort, int deviceCount = 1, Max7219Type maxMode = Max7219Type.Display)
             :this(spiBus, csPort, 8, 1, maxMode)
         {
@@ -139,15 +132,13 @@ namespace Meadow.Foundation.Displays
         /// Creates a Max7219 Device given a <see paramref="spiBus" /> to communicate over and the
         /// number of devices that are cascaded.
         /// </summary>
-        public Max7219(IIODevice device, ISpiBus spiBus, IPin csPin, int deviceRows = 1, int deviceColumns = 1, Max7219Type maxMode = Max7219Type.Display)
+        public Max7219(IMeadowDevice device, ISpiBus spiBus, IPin csPin, int deviceRows = 1, int deviceColumns = 1, Max7219Type maxMode = Max7219Type.Display)
             : this(spiBus, device.CreateDigitalOutputPort(csPin), deviceRows, deviceColumns, maxMode)
         { }
 
-        public Max7219(IIODevice device, ISpiBus spiBus, IPin csPin, int deviceCount = 1, Max7219Type maxMode = Max7219Type.Display)
+        public Max7219(IMeadowDevice device, ISpiBus spiBus, IPin csPin, int deviceCount = 1, Max7219Type maxMode = Max7219Type.Display)
             : this(spiBus, device.CreateDigitalOutputPort(csPin), deviceCount, 1, maxMode)
         { }
-
-        
 
         /// <summary>
         /// Standard initialization routine.

--- a/Source/Meadow.Foundation.Peripherals/Displays.Pcd8544/Driver/Displays.Pcd8544/Pcd8544.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Pcd8544/Driver/Displays.Pcd8544/Pcd8544.cs
@@ -1,4 +1,3 @@
-using System;
 using Meadow.Devices;
 using Meadow.Hardware;
 

--- a/Source/Meadow.Foundation.Peripherals/Displays.Pcd8544/Driver/Displays.Pcd8544/Pcd8544.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Pcd8544/Driver/Displays.Pcd8544/Pcd8544.cs
@@ -1,4 +1,5 @@
 using System;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays
@@ -31,7 +32,7 @@ namespace Meadow.Foundation.Displays
         protected byte[] displayBuffer;
         protected readonly byte[] spiReceive;
 
-        public Pcd8544(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin)
+        public Pcd8544(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin)
         {
             displayBuffer = new byte[Width * Height / 8];
             spiReceive = new byte[Width * Height / 8];

--- a/Source/Meadow.Foundation.Peripherals/Displays.ST7565/Driver/Displays.ST7565/ST7565.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ST7565/Driver/Displays.ST7565/ST7565.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays
@@ -9,8 +10,6 @@ namespace Meadow.Foundation.Displays
     /// </summary>
     public class St7565 : DisplayBase
     {
-        
-
         /// <summary>
         ///     Allow the programmer to set the scroll direction.
         /// </summary>
@@ -62,10 +61,6 @@ namespace Meadow.Foundation.Displays
             NoOperation = 0xE3
         }
 
-        
-
-        
-
         public override DisplayColorMode ColorMode => DisplayColorMode.Format1bpp;
 
         public override int Width { get; }
@@ -91,10 +86,6 @@ namespace Meadow.Foundation.Displays
         /// </summary>
         private byte[] buffer;
 
-        
-
-        
-
         /// <summary>
         ///     Invert the entire display (true) or return to normal mode (false).
         /// </summary>
@@ -116,14 +107,10 @@ namespace Meadow.Foundation.Displays
             SendCommand(DisplayCommand.AllPixelsOn);
         }
 
-        
-
-        
-
         /// <summary>
         ///     Create a new ST7565 object using the default parameters for
         /// </summary>
-        public St7565(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public St7565(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width = 128, int height = 64)
         {
             dataCommandPort = device.CreateDigitalOutputPort(dcPin, false);
@@ -170,10 +157,6 @@ namespace Meadow.Foundation.Displays
             SendCommand(DisplayCommand.DisplayOn);
             SendCommand(DisplayCommand.AllPixelsOff);
         }
-
-        
-
-        
 
         public const uint ContrastHigh = 34;
         public const uint ContrastMedium = 24;
@@ -381,7 +364,5 @@ namespace Meadow.Foundation.Displays
         {
             SendCommand(0x2e);
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Displays.SerialLcd/Driver/Displays.SerialLcd/SerialLcd.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.SerialLcd/Driver/Displays.SerialLcd/SerialLcd.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using Meadow.Peripherals.Displays;
 using System;
 using System.Threading;
@@ -101,7 +102,7 @@ namespace Meadow.Foundation.Displays
         /// <param name="parity">Parity to use (default is None).</param>
         /// <param name="dataBits">Number of data bits (default is 8 data bits).</param>
         /// <param name="stopBits">Number of stop bits (default is one stop bit).</param>
-        public SerialLcd(IIODevice device, SerialPortName port, TextDisplayConfig config = null, int baudRate = 9600,
+        public SerialLcd(IMeadowDevice device, SerialPortName port, TextDisplayConfig config = null, int baudRate = 9600,
             Parity parity = Parity.None, int dataBits = 8, StopBits stopBits = StopBits.One)
         {
             if (config == null)

--- a/Source/Meadow.Foundation.Peripherals/Displays.Ssd130x/Driver/Displays.Ssd130x/Drivers/Ssd1306.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Ssd130x/Driver/Displays.Ssd130x/Drivers/Ssd1306.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays
@@ -236,7 +237,7 @@ namespace Meadow.Foundation.Displays
         /// </remarks>
         /// <param name="displayType">Type of SSD1306 display (default = 128x64 pixel display).</param>
         ///
-        public Ssd1306(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public Ssd1306(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             DisplayType displayType = DisplayType.OLED128x64)
         {
             dataCommandPort = device.CreateDigitalOutputPort(dcPin, false);

--- a/Source/Meadow.Foundation.Peripherals/Displays.Ssd130x/Driver/Displays.Ssd130x/Drivers/Ssd1309.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Ssd130x/Driver/Displays.Ssd130x/Drivers/Ssd1309.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays
@@ -14,7 +15,7 @@ namespace Meadow.Foundation.Displays
         ///     property to true.
         /// </remarks>
         ///
-        public Ssd1309(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin) :
+        public Ssd1309(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin) :
             base(device, spiBus, chipSelectPin, dcPin, resetPin, DisplayType.OLED128x64)
         {
         }

--- a/Source/Meadow.Foundation.Peripherals/Displays.Ssd1327/Driver/Displays.Ssd1327/Ssd1327.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Ssd1327/Driver/Displays.Ssd1327/Ssd1327.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays
@@ -29,7 +30,7 @@ namespace Meadow.Foundation.Displays
         protected const bool Data = true;
         protected const bool Command = false;
 
-        public Ssd1327(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin)
+        public Ssd1327(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin)
         {
             this.spiBus = (SpiBus)spiBus;
 

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Gc9a01.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Gc9a01.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.Tft
@@ -7,7 +8,7 @@ namespace Meadow.Foundation.Displays.Tft
     {
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format16bppRgb565;
 
-        public Gc9a01(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin) :
+        public Gc9a01(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin) :
             base(device, spiBus, chipSelectPin, dcPin, resetPin, 240, 240, DisplayColorMode.Format16bppRgb565)
         {
             Initialize();

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Hx8357b.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Hx8357b.cs
@@ -1,11 +1,12 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System.Threading;
 
 namespace Meadow.Foundation.Displays.Tft
 {
     public class Hx8357b : Hx8357d
     {
-        public Hx8357b(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public Hx8357b(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width = 320, int height = 480, DisplayColorMode displayColorMode = DisplayColorMode.Format16bppRgb565)
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Hx8357d.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Hx8357d.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.Tft
@@ -7,7 +8,7 @@ namespace Meadow.Foundation.Displays.Tft
     {
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format16bppRgb565;
 
-        public Hx8357d(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public Hx8357d(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width = 320, int height = 480, DisplayColorMode displayColorMode = DisplayColorMode.Format16bppRgb565)
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ili9163.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ili9163.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System.Threading;
 
 namespace Meadow.Foundation.Displays.Tft
@@ -7,7 +8,7 @@ namespace Meadow.Foundation.Displays.Tft
     {
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format12bppRgb444;
 
-        public Ili9163(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public Ili9163(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width, int height, DisplayColorMode displayColorMode = DisplayColorMode.Format12bppRgb444) 
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ili9341.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ili9341.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.Tft
@@ -7,7 +8,7 @@ namespace Meadow.Foundation.Displays.Tft
     {
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format12bppRgb444;
 
-        public Ili9341(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public Ili9341(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width, int height, DisplayColorMode displayColorMode = DisplayColorMode.Format12bppRgb444)
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ili9481.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ili9481.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using Meadow.Devices;
 using Meadow.Foundation.Displays.Tft;
 using Meadow.Hardware;
 
@@ -9,7 +10,7 @@ namespace Meadow.Foundation.Displays.Tft
     {
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format12bppRgb444;
 
-        public Ili9481(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public Ili9481(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width = 320, int height = 480, DisplayColorMode displayColorMode = DisplayColorMode.Format12bppRgb444) 
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ili9486.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ili9486.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.Tft
@@ -7,7 +8,7 @@ namespace Meadow.Foundation.Displays.Tft
     {
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format12bppRgb444;
 
-        public Ili9486(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public Ili9486(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width = 320, int height = 480, DisplayColorMode displayColorMode = DisplayColorMode.Format12bppRgb444) 
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ili9488.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ili9488.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.Tft
@@ -7,7 +8,7 @@ namespace Meadow.Foundation.Displays.Tft
     {
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format12bppRgb444;
 
-        public Ili9488(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public Ili9488(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width = 320, int height = 480, DisplayColorMode displayColorMode = DisplayColorMode.Format12bppRgb444) 
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Rm68140.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Rm68140.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.Tft
@@ -7,7 +8,7 @@ namespace Meadow.Foundation.Displays.Tft
     {
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format12bppRgb444;
 
-        public Rm68140(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public Rm68140(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width = 320, int height = 480, DisplayColorMode displayColorMode = DisplayColorMode.Format12bppRgb444) 
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/S6D02A1.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/S6D02A1.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 using System;
 using System.Threading;
@@ -9,7 +10,7 @@ namespace Meadow.Foundation.Displays.Tft
     {
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format12bppRgb444;
 
-        public S6D02A1(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public S6D02A1(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width, int height, DisplayColorMode displayColorMode = DisplayColorMode.Format12bppRgb444)
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/ST7735.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/ST7735.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 using System.Threading;
 
@@ -12,7 +13,7 @@ namespace Meadow.Foundation.Displays.Tft
 
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format12bppRgb444;
 
-        public St7735(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public St7735(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width, int height,
             DisplayType displayType = DisplayType.ST7735R, DisplayColorMode displayColorMode = DisplayColorMode.Format12bppRgb444)
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/ST7789.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/ST7789.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 using System;
 using System.Threading;
@@ -11,7 +12,7 @@ namespace Meadow.Foundation.Displays.Tft
 
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format12bppRgb444;
 
-        public St7789(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public St7789(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width, int height, DisplayColorMode displayColorMode = DisplayColorMode.Format12bppRgb444) 
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ssd1331.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ssd1331.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 using System.Threading;
 
@@ -8,7 +9,7 @@ namespace Meadow.Foundation.Displays.Tft
         //the SSD1331 also supports 8 bit RGB332 color but this isn't currently supported (but should be quick to add if anyone wants it
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format16bppRgb565;
 
-        public Ssd1331(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public Ssd1331(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
            int width, int height) 
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, DisplayColorMode.Format16bppRgb565)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ssd1351.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/Ssd1351.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 using System.Threading;
 
@@ -7,7 +8,7 @@ namespace Meadow.Foundation.Displays.Tft
     {
         public override DisplayColorMode DefautColorMode => DisplayColorMode.Format16bppRgb565;
 
-        public Ssd1351(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public Ssd1351(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width, int height)
             : base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, DisplayColorMode.Format16bppRgb565)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/St7796s.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/Drivers/St7796s.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.Tft
@@ -7,7 +8,7 @@ namespace Meadow.Foundation.Displays.Tft
     {
 		public override DisplayColorMode DefautColorMode => DisplayColorMode.Format12bppRgb444;
 
-		public St7796s(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+		public St7796s(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width = 320, int height = 480, DisplayColorMode displayColorMode = DisplayColorMode.Format12bppRgb444)
 			: base(device, spiBus, chipSelectPin, dcPin, resetPin, width, height, displayColorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/TftSpiBase.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Displays.TftSpi/TftSpiBase.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 using System;
 using System.Threading;
@@ -67,7 +68,7 @@ namespace Meadow.Foundation.Displays.Tft
         internal TftSpiBase()
         { }
 
-        public TftSpiBase(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public TftSpiBase(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
             int width, int height, DisplayColorMode mode = DisplayColorMode.Format16bppRgb565)
         {
             this.width = width;

--- a/Source/Meadow.Foundation.Peripherals/Displays.Tm1637/Driver/Displays.Tm1637/Tm1637.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Tm1637/Driver/Displays.Tm1637/Tm1637.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays
@@ -71,13 +72,11 @@ namespace Meadow.Foundation.Displays
             }
         }
         private byte _brightness;
-        
 
         private readonly IDigitalOutputPort portClock;
         private readonly IBiDirectionalPort portData;
 
         private byte[] displayBuffer = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-
 
         /// <summary>
         /// Internal registers to be send to the TM1637
@@ -106,7 +105,7 @@ namespace Meadow.Foundation.Displays
         /// </summary>
         /// <param name="pinClock">The clock pin</param>
         /// <param name="pinData">The data pin</param>
-        public Tm1637(IIODevice device, IPin pinClock, IPin pinData)
+        public Tm1637(IMeadowDevice device, IPin pinClock, IPin pinData)
         {
             portClock = device.CreateDigitalOutputPort(pinClock);
             portData = device.CreateBiDirectionalPort(pinData);
@@ -304,7 +303,5 @@ namespace Meadow.Foundation.Displays
             };
             Show(clearDisplay);
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL0373.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL0373.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.ePaper
@@ -10,7 +11,7 @@ namespace Meadow.Foundation.Displays.ePaper
     /// </summary>
     public class Il0373 : EpdColorBase
     {
-        public Il0373(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
+        public Il0373(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
             int width, int height) :
             base(device, spiBus, chipSelectPin, dcPin, resetPin, busyPin, width, height)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL0376F.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL0376F.cs
@@ -1,4 +1,5 @@
 using System;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.ePaper
@@ -11,7 +12,7 @@ namespace Meadow.Foundation.Displays.ePaper
     /// </summary>
     public class Il0376F : EpdColorBase
     {
-        public Il0376F(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
+        public Il0376F(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
             int width = 200, int height = 200) :
             base(device, spiBus, chipSelectPin, dcPin, resetPin, busyPin, width, height)
         { }

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL0398.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL0398.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 using System.Threading;
 
@@ -10,7 +11,7 @@ namespace Meadow.Foundation.Displays.ePaper
     /// </summary>
     public class Il0398 : EpdColorBase
     {
-        public Il0398(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
+        public Il0398(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
             int width, int height) :
             base(device, spiBus, chipSelectPin, dcPin, resetPin, busyPin, width, height)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL3897.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL3897.cs
@@ -1,4 +1,5 @@
 using System;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.ePaper
@@ -9,7 +10,7 @@ namespace Meadow.Foundation.Displays.ePaper
     /// </summary>
     public class Il3897 : EpdBase
     {
-        public Il3897(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
+        public Il3897(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
             int width = 122, int height = 250) :
             base(device, spiBus, chipSelectPin, dcPin, resetPin, busyPin, width, height)
         { }

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL91874.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL91874.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.ePaper
@@ -9,7 +10,7 @@ namespace Meadow.Foundation.Displays.ePaper
     /// </summary>
     public class Il91874 : EpdColorBase
     {
-        public Il91874(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
+        public Il91874(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
             int width = 176, int height = 264) :
             base(device, spiBus, chipSelectPin, dcPin, resetPin, busyPin, width, height)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL91874V03.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/IL91874V03.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.ePaper
@@ -11,7 +12,7 @@ namespace Meadow.Foundation.Displays.ePaper
     /// </summary>
     public class Il91874V03 : EpdBase
     {
-        public Il91874V03(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
+        public Il91874V03(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
             int width = 176, int height = 264) :
             base(device, spiBus, chipSelectPin, dcPin, resetPin, busyPin, width, height)
         { }

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/SSD1608.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/SSD1608.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.ePaper
@@ -8,7 +9,7 @@ namespace Meadow.Foundation.Displays.ePaper
     /// </summary>
     public class Ssd1608 : EpdBase
     {
-        public Ssd1608(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
+        public Ssd1608(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
             int width = 200, int height = 200) :
             base(device, spiBus, chipSelectPin, dcPin, resetPin, busyPin, width, height)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/SSD1681.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/Drivers/SSD1681.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Foundation.Displays.ePaper;
+﻿using Meadow.Devices;
+using Meadow.Foundation.Displays.ePaper;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.ePaper
@@ -67,7 +68,7 @@ namespace Meadow.Foundation.Displays.ePaper
         public static byte[] LutData = { 0x02, 0x02, 0x01, 0x11, 0x12, 0x12 }; //""fiiYX\x99\x99\x88\x00\x00\x00\x00\xf8\xb4\x13Q5QQ\x19\x01\x00' };
         //_LUT_DATA = b'\x02\x02\x01\x11\x12\x12""fiiYX\x99\x99\x88\x00\x00\x00\x00\xf8\xb4\x13Q5QQ\x19\x01\x00'
 
-        public Ssd1681(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
+        public Ssd1681(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
             int width, int height) :
             base(device, spiBus, chipSelectPin, dcPin, resetPin, busyPin, width, height)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/ePaperBase.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/ePaperBase.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 
 namespace Meadow.Foundation.Displays.ePaper
@@ -20,7 +21,7 @@ namespace Meadow.Foundation.Displays.ePaper
         private EpdBase()
         { }
 
-        public EpdBase(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
+        public EpdBase(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
             int width, int height)
         {
             Width = width;

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/ePaperColorBase.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Displays.ePaper/ePaperColorBase.cs
@@ -1,4 +1,5 @@
 using System;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays.ePaper
@@ -27,7 +28,7 @@ namespace Meadow.Foundation.Displays.ePaper
         private EpdColorBase()
         {  }
 
-        public EpdColorBase(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
+        public EpdColorBase(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin, IPin busyPin,
             int width, int height)
         {
             this.width = width;

--- a/Source/Meadow.Foundation.Peripherals/FeatherWings.JoyWing/Driver/FeatherWings.JoyWing/JoyWing.cs
+++ b/Source/Meadow.Foundation.Peripherals/FeatherWings.JoyWing/Driver/FeatherWings.JoyWing/JoyWing.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Meadow.Devices;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Buttons;
 
@@ -21,7 +22,7 @@ namespace Meadow.Foundation.FeatherWings
         public IButton ButtonB { get; private set; }
         public IButton ButtonSelect { get; private set; }
 
-        public JoyWing(IIODevice device, IPin pinX, IPin pinY, IPin pinA, IPin pinB, IPin pinSelect,
+        public JoyWing(IMeadowDevice device, IPin pinX, IPin pinY, IPin pinA, IPin pinB, IPin pinSelect,
             IPin pinJoyHorizontal, IPin pinJoyVertical) :
             this(device.CreateDigitalInputPort(pinX, InterruptMode.EdgeRising),
                 device.CreateDigitalInputPort(pinY, InterruptMode.EdgeRising),

--- a/Source/Meadow.Foundation.Peripherals/FeatherWings.JoyWing/Driver/FeatherWings.JoyWing/JoyWing.cs
+++ b/Source/Meadow.Foundation.Peripherals/FeatherWings.JoyWing/Driver/FeatherWings.JoyWing/JoyWing.cs
@@ -22,7 +22,7 @@ namespace Meadow.Foundation.FeatherWings
         public IButton ButtonB { get; private set; }
         public IButton ButtonSelect { get; private set; }
 
-        public JoyWing(IMeadowDevice device, IPin pinX, IPin pinY, IPin pinA, IPin pinB, IPin pinSelect,
+        public JoyWing(IDigitalInputController device, IPin pinX, IPin pinY, IPin pinA, IPin pinB, IPin pinSelect,
             IPin pinJoyHorizontal, IPin pinJoyVertical) :
             this(device.CreateDigitalInputPort(pinX, InterruptMode.EdgeRising),
                 device.CreateDigitalInputPort(pinY, InterruptMode.EdgeRising),

--- a/Source/Meadow.Foundation.Peripherals/FeatherWings.OLED128x32Wing/Driver/FeatherWings.OLED128x32Wing/OLED128x32Wing.cs
+++ b/Source/Meadow.Foundation.Peripherals/FeatherWings.OLED128x32Wing/Driver/FeatherWings.OLED128x32Wing/OLED128x32Wing.cs
@@ -19,7 +19,7 @@ namespace Meadow.Foundation.FeatherWings
 
         public PushButton ButtonC { get; protected set; }
 
-        public OLED128x32Wing(II2cBus i2cBus, IMeadowDevice device, IPin pinA, IPin pinB, IPin pinC) : 
+        public OLED128x32Wing(II2cBus i2cBus, IDigitalInputController device, IPin pinA, IPin pinB, IPin pinC) : 
             this(i2cBus, 
                 device.CreateDigitalInputPort(pinA, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp),
                 device.CreateDigitalInputPort(pinB, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp),

--- a/Source/Meadow.Foundation.Peripherals/FeatherWings.OLED128x32Wing/Driver/FeatherWings.OLED128x32Wing/OLED128x32Wing.cs
+++ b/Source/Meadow.Foundation.Peripherals/FeatherWings.OLED128x32Wing/Driver/FeatherWings.OLED128x32Wing/OLED128x32Wing.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Foundation.Displays;
+﻿using Meadow.Devices;
+using Meadow.Foundation.Displays;
 using Meadow.Foundation.Sensors.Buttons;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Buttons;
@@ -18,7 +19,7 @@ namespace Meadow.Foundation.FeatherWings
 
         public PushButton ButtonC { get; protected set; }
 
-        public OLED128x32Wing(II2cBus i2cBus, IIODevice device, IPin pinA, IPin pinB, IPin pinC) : 
+        public OLED128x32Wing(II2cBus i2cBus, IMeadowDevice device, IPin pinA, IPin pinB, IPin pinC) : 
             this(i2cBus, 
                 device.CreateDigitalInputPort(pinA, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp),
                 device.CreateDigitalInputPort(pinB, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp),

--- a/Source/Meadow.Foundation.Peripherals/ICs.EEPROM.AT24Cxx/Driver/ICs.EEPROM.AT24Cxx/AT24Cxx.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.EEPROM.AT24Cxx/Driver/ICs.EEPROM.AT24Cxx/AT24Cxx.cs
@@ -5,7 +5,7 @@ using Meadow.Hardware;
 namespace Meadow.Foundation.ICs.EEPROM
 {
     /// <summary>
-    ///     Encapsulation for EEPROMs based upon the AT24Cxx family of chips.
+    /// Encapsulation for EEPROMs based upon the AT24Cxx family of chips.
     /// </summary>
     public class At24Cxx
     {
@@ -23,7 +23,6 @@ namespace Meadow.Foundation.ICs.EEPROM
         ///     Number of bytes in the EEPROM module.
         /// </summary>
         private readonly ushort _memorySize;
-
 
         /// <summary>
         ///     Create a new AT24Cxx object using the default parameters for the component.
@@ -96,7 +95,5 @@ namespace Meadow.Foundation.ICs.EEPROM
                 Thread.Sleep(10);
             }
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.HT16K33/Driver/ICs.IOExpanders.HT16K33/HT16K33.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.HT16K33/Driver/ICs.IOExpanders.HT16K33/HT16K33.cs
@@ -69,8 +69,6 @@ namespace Meadow.Foundation.ICs.IOExpanders
             InitHT16K33();
         }
 
-        
-
         void InitHT16K33()
         {
             //   SetIsAwake(true);

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Mcp23x08/Driver/ICs.IOExpanders.MCP23x08/Mcp23x08.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Mcp23x08/Driver/ICs.IOExpanders.MCP23x08/Mcp23x08.cs
@@ -10,7 +10,7 @@ namespace Meadow.Foundation.ICs.IOExpanders
     /// <summary>
     /// Provide an interface to connect to a MCP23008 port expander.
     /// </summary>
-    public partial class Mcp23x08 : IDigitalInputDevice, IDigitalOutputDevice
+    public partial class Mcp23x08 : IDigitalInputController, IDigitalOutputController
     {
         /// <summary>
         /// Raised when the value of a pin configured for input changes. Use in

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.x74595/Driver/ICs.IOExpanders.x74595/x74595.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.x74595/Driver/ICs.IOExpanders.x74595/x74595.cs
@@ -14,7 +14,7 @@ namespace Meadow.Foundation.ICs.IOExpanders
     /// Control the outputs from a 74595 shift register (or a chain of shift registers)
     /// using a SPI interface.
     /// </remarks>
-    public partial class x74595 : IDigitalOutputDevice
+    public partial class x74595 : IDigitalOutputController
     {
         public PinDefinitions Pins { get; } = new PinDefinitions();
 

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.x74595/Driver/ICs.IOExpanders.x74595/x74595.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.x74595/Driver/ICs.IOExpanders.x74595/x74595.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 using Meadow.Utilities;
 
@@ -13,19 +14,9 @@ namespace Meadow.Foundation.ICs.IOExpanders
     /// Control the outputs from a 74595 shift register (or a chain of shift registers)
     /// using a SPI interface.
     /// </remarks>
-    public partial class x74595 : IIODevice
+    public partial class x74595 : IDigitalOutputDevice
     {
-        
-
         public PinDefinitions Pins { get; } = new PinDefinitions();
-
-        
-
-        
-
-        
-
-        
 
         /// <summary>
         ///     Number of chips required to implement this ShiftRegister.
@@ -38,12 +29,6 @@ namespace Meadow.Foundation.ICs.IOExpanders
         ///     SPI interface used to communicate with the shift registers.
         /// </summary>
         private readonly ISpiPeripheral _spi;
-
-        public DeviceCapabilities Capabilities => throw new NotImplementedException();
-
-        
-
-        
 
         /// <summary>
         ///     Default constructor.
@@ -60,7 +45,7 @@ namespace Meadow.Foundation.ICs.IOExpanders
         /// </summary>
         /// <param name="pins">Number of pins in the shift register (should be a multiple of 8 pins).</param>
         /// <param name="spiBus">SpiBus object</param>
-        public x74595(IIODevice device, ISpiBus spiBus, IPin pinChipSelect, int pins = 8)
+        public x74595(IMeadowDevice device, ISpiBus spiBus, IPin pinChipSelect, int pins = 8)
         {
            // if ((pins > 0) && ((pins % 8) == 0))
             if(pins == 8)
@@ -77,10 +62,6 @@ namespace Meadow.Foundation.ICs.IOExpanders
                     "x74595: Size must be greater than zero and a multiple of 8 pins, driver is currently limited to one chip (8 pins)");
             }
         }
-
-        
-
-        
 
         /// <summary>
         /// Creates a new DigitalOutputPort using the specified pin and initial state.
@@ -136,107 +117,9 @@ namespace Meadow.Foundation.ICs.IOExpanders
             return Pins.AllPins.Contains(pin);
         }
 
-        public IDigitalInputPort CreateDigitalInputPort(IPin pin, 
-            InterruptMode interruptMode = InterruptMode.None, 
-            ResistorMode resistorMode = ResistorMode.Disabled, 
-            double debounceDuration = 0,
-            double glitchFilterCycleCount = 0)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IBiDirectionalPort CreateBiDirectionalPort(IPin pin,
-            bool initialState = false,
-            InterruptMode interruptMode = InterruptMode.None,
-            ResistorMode resistorMode = ResistorMode.Disabled,
-            PortDirectionType initialDirection = PortDirectionType.Input,
-            double debounceDuration = 0.0,    // 0 - 1000 msec in .1 increments
-            double glitchDuration = 0.0,      // 0 - 1000 msec in .1 increments
-            OutputType outputType = OutputType.PushPull
-            )
-        {
-            throw new NotImplementedException();
-        }
-
-        //TODO: we know adding all these sucks. when we convert to .NET Core
-        // we'll be able to add these to the IIODevice interface implementation
-        // and they won't be necessary to put in like this.
-
-        public IAnalogInputPort CreateAnalogInputPort(IPin pin, float voltageReference = 3.3F)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IPwmPort CreatePwmPort(IPin pin, float frequency = 100, float dutyCycle = 0.5F, bool invert = false)
-        {
-            throw new NotImplementedException();
-        }
-
-        public ISerialPort CreateSerialPort(SerialPortName portName, int baudRate = 9600, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One, int readBufferSize = 4096)
-        {
-            throw new NotImplementedException();
-        }
-
-        public ISpiBus CreateSpiBus(IPin[] pins, long speed)
-        {
-            throw new NotImplementedException();
-        }
-
-        public ISpiBus CreateSpiBus(IPin clock, IPin mosi, IPin miso, long speed)
-        {
-            throw new NotImplementedException();
-        }
-
-        public II2cBus CreateI2cBus(IPin[] pins, ushort speed = 100)
-        {
-            throw new NotImplementedException();
-        }
-
-        public II2cBus CreateI2cBus(IPin clock, IPin data, ushort speed = 100)
-        {
-            throw new NotImplementedException();
-        }
-
-        public ISpiBus CreateSpiBus(IPin clock, IPin mosi, IPin miso, SpiClockConfiguration config)
-        {
-            throw new NotImplementedException();
-        }
-
-        public II2cBus CreateI2cBus(IPin[] pins, int frequencyHz = 100000)
-        {
-            throw new NotImplementedException();
-        }
-
-        public II2cBus CreateI2cBus(IPin clock, IPin data, int frequencyHz = 100000)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetClock(DateTime dateTime)
-        {
-            throw new NotImplementedException();
-        }
-
-        public ISerialMessagePort CreateSerialMessagePort(SerialPortName portName, byte[] suffixDelimiter, bool preserveDelimiter, int baudRate = 9600, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One, int readBufferSize = 512)
-        {
-            throw new NotImplementedException();
-        }
-
-        public ISerialMessagePort CreateSerialMessagePort(SerialPortName portName, byte[] prefixDelimiter, bool preserveDelimiter, int messageLength, int baudRate = 9600, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One, int readBufferSize = 512)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetSynchronizationContext(SynchronizationContext context)
-        {
-            throw new NotImplementedException();
-        }
-
         public IPin GetPin(string pinName)
         {
             return Pins.AllPins.FirstOrDefault(p => p.Name == pinName || p.Key.ToString() == p.Name);
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Motors.Stepper.A4988/Driver/Motors.Stepper.A4988/A4988.cs
+++ b/Source/Meadow.Foundation.Peripherals/Motors.Stepper.A4988/Driver/Motors.Stepper.A4988/A4988.cs
@@ -33,7 +33,7 @@ namespace Meadow.Foundation.Motors.Stepper
         /// <param name="step">The Meadow pin connected to the STEP pin of the A4988</param>
         /// <param name="direction">The Meadow pin connected to the DIR pin of the A4988</param>
         /// <remarks>You must provide either all of the micro-step (MS) lines or none of them</remarks>
-        public A4988(IMeadowDevice device, IPin step, IPin direction)
+        public A4988(IDigitalOutputController device, IPin step, IPin direction)
             : this(device, step, direction, null, null, null, null)
         {
         }
@@ -48,7 +48,7 @@ namespace Meadow.Foundation.Motors.Stepper
         /// <param name="ms2">The (optional) Meadow pin connected to the MS2 pin of the A4988</param>
         /// <param name="ms3">The (optional) Meadow pin connected to the MS3 pin of the A4988</param>
         /// <remarks>You must provide either all of the micro-step (MS) lines or none of them</remarks>
-        public A4988(IMeadowDevice device, IPin step, IPin direction, IPin ms1, IPin ms2, IPin ms3)
+        public A4988(IDigitalOutputController device, IPin step, IPin direction, IPin ms1, IPin ms2, IPin ms3)
             : this(device, step, direction, null, ms1, ms2, ms3)
         {
 
@@ -61,7 +61,7 @@ namespace Meadow.Foundation.Motors.Stepper
         /// <param name="step">The Meadow pin connected to the STEP pin of the A4988</param>
         /// <param name="direction">The Meadow pin connected to the DIR pin of the A4988</param>
         /// <param name="enable">The (optional) Meadow pin connected to the ENABLE pin of the A4988</param>
-        public A4988(IMeadowDevice device, IPin step, IPin direction, IPin enable)
+        public A4988(IDigitalOutputController device, IPin step, IPin direction, IPin enable)
             : this(device, step, direction, enable, null, null, null)
         {
 
@@ -78,7 +78,7 @@ namespace Meadow.Foundation.Motors.Stepper
         /// <param name="ms2">The (optional) Meadow pin connected to the MS2 pin of the A4988</param>
         /// <param name="ms3">The (optional) Meadow pin connected to the MS3 pin of the A4988</param>
         /// <remarks>You must provide either all of the micro-step (MS) lines or none of them</remarks>
-        public A4988(IMeadowDevice device, IPin step, IPin direction, IPin enable, IPin ms1, IPin ms2, IPin ms3)
+        public A4988(IDigitalOutputController device, IPin step, IPin direction, IPin enable, IPin ms1, IPin ms2, IPin ms3)
         {
             stepPort = device.CreateDigitalOutputPort(step);
             directionPort = device.CreateDigitalOutputPort(direction);

--- a/Source/Meadow.Foundation.Peripherals/Motors.Stepper.A4988/Driver/Motors.Stepper.A4988/A4988.cs
+++ b/Source/Meadow.Foundation.Peripherals/Motors.Stepper.A4988/Driver/Motors.Stepper.A4988/A4988.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Linq;
+﻿using Meadow.Devices;
 using Meadow.Hardware;
+using System;
+using System.Linq;
 
 namespace Meadow.Foundation.Motors.Stepper
 {
@@ -32,7 +33,7 @@ namespace Meadow.Foundation.Motors.Stepper
         /// <param name="step">The Meadow pin connected to the STEP pin of the A4988</param>
         /// <param name="direction">The Meadow pin connected to the DIR pin of the A4988</param>
         /// <remarks>You must provide either all of the micro-step (MS) lines or none of them</remarks>
-        public A4988(IIODevice device, IPin step, IPin direction)
+        public A4988(IMeadowDevice device, IPin step, IPin direction)
             : this(device, step, direction, null, null, null, null)
         {
         }
@@ -47,7 +48,7 @@ namespace Meadow.Foundation.Motors.Stepper
         /// <param name="ms2">The (optional) Meadow pin connected to the MS2 pin of the A4988</param>
         /// <param name="ms3">The (optional) Meadow pin connected to the MS3 pin of the A4988</param>
         /// <remarks>You must provide either all of the micro-step (MS) lines or none of them</remarks>
-        public A4988(IIODevice device, IPin step, IPin direction, IPin ms1, IPin ms2, IPin ms3)
+        public A4988(IMeadowDevice device, IPin step, IPin direction, IPin ms1, IPin ms2, IPin ms3)
             : this(device, step, direction, null, ms1, ms2, ms3)
         {
 
@@ -60,7 +61,7 @@ namespace Meadow.Foundation.Motors.Stepper
         /// <param name="step">The Meadow pin connected to the STEP pin of the A4988</param>
         /// <param name="direction">The Meadow pin connected to the DIR pin of the A4988</param>
         /// <param name="enable">The (optional) Meadow pin connected to the ENABLE pin of the A4988</param>
-        public A4988(IIODevice device, IPin step, IPin direction, IPin enable)
+        public A4988(IMeadowDevice device, IPin step, IPin direction, IPin enable)
             : this(device, step, direction, enable, null, null, null)
         {
 
@@ -77,7 +78,7 @@ namespace Meadow.Foundation.Motors.Stepper
         /// <param name="ms2">The (optional) Meadow pin connected to the MS2 pin of the A4988</param>
         /// <param name="ms3">The (optional) Meadow pin connected to the MS3 pin of the A4988</param>
         /// <remarks>You must provide either all of the micro-step (MS) lines or none of them</remarks>
-        public A4988(IIODevice device, IPin step, IPin direction, IPin enable, IPin ms1, IPin ms2, IPin ms3)
+        public A4988(IMeadowDevice device, IPin step, IPin direction, IPin enable, IPin ms1, IPin ms2, IPin ms3)
         {
             stepPort = device.CreateDigitalOutputPort(step);
             directionPort = device.CreateDigitalOutputPort(direction);

--- a/Source/Meadow.Foundation.Peripherals/Motors.Stepper.Uln2003/Driver/Motors.Stepper.Uln2003/Uln2003.cs
+++ b/Source/Meadow.Foundation.Peripherals/Motors.Stepper.Uln2003/Driver/Motors.Stepper.Uln2003/Uln2003.cs
@@ -106,7 +106,7 @@ namespace Meadow.Foundation.Motors.Stepper
         /// <param name="pin2">The GPIO pin number which corresponds pin B on ULN2003 driver board.</param>
         /// <param name="pin3">The GPIO pin number which corresponds pin C on ULN2003 driver board.</param>
         /// <param name="pin4">The GPIO pin number which corresponds pin D on ULN2003 driver board.</param>
-        public Uln2003(IMeadowDevice device, IPin pin1, IPin pin2, IPin pin3, IPin pin4)
+        public Uln2003(IDigitalOutputController device, IPin pin1, IPin pin2, IPin pin3, IPin pin4)
         {
             outputPort1 = device.CreateDigitalOutputPort(pin1);
             outputPort2 = device.CreateDigitalOutputPort(pin2);

--- a/Source/Meadow.Foundation.Peripherals/Motors.Stepper.Uln2003/Driver/Motors.Stepper.Uln2003/Uln2003.cs
+++ b/Source/Meadow.Foundation.Peripherals/Motors.Stepper.Uln2003/Driver/Motors.Stepper.Uln2003/Uln2003.cs
@@ -1,5 +1,6 @@
-﻿using System;
+﻿using Meadow.Devices;
 using Meadow.Hardware;
+using System;
 
 namespace Meadow.Foundation.Motors.Stepper
 {
@@ -105,7 +106,7 @@ namespace Meadow.Foundation.Motors.Stepper
         /// <param name="pin2">The GPIO pin number which corresponds pin B on ULN2003 driver board.</param>
         /// <param name="pin3">The GPIO pin number which corresponds pin C on ULN2003 driver board.</param>
         /// <param name="pin4">The GPIO pin number which corresponds pin D on ULN2003 driver board.</param>
-        public Uln2003(IIODevice device, IPin pin1, IPin pin2, IPin pin3, IPin pin4)
+        public Uln2003(IMeadowDevice device, IPin pin1, IPin pin2, IPin pin3, IPin pin4)
         {
             outputPort1 = device.CreateDigitalOutputPort(pin1);
             outputPort2 = device.CreateDigitalOutputPort(pin2);
@@ -173,7 +174,5 @@ namespace Meadow.Foundation.Motors.Stepper
             outputPort3.State = currentSwitchingSequence[2, engineStep - 1];
             outputPort4.State = currentSwitchingSequence[3, engineStep - 1];
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Motors.Tb67h420ftg/Driver/Motors.Tb67h420ftg/Tb67h420ftg.cs
+++ b/Source/Meadow.Foundation.Peripherals/Motors.Tb67h420ftg/Driver/Motors.Tb67h420ftg/Tb67h420ftg.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
-
-using System;
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Motors
@@ -42,7 +41,7 @@ namespace Meadow.Foundation.Motors
         public HBridgeMotor Motor1 { get; protected set; }
         public HBridgeMotor? Motor2 { get; protected set; }
 
-        public Tb67h420ftg(IIODevice device,
+        public Tb67h420ftg(IMeadowDevice device,
             IPin inA1, IPin inA2, IPin pwmA,
             IPin? inB1, IPin? inB2, IPin? pwmB,
             IPin? fault1, IPin? fault2,
@@ -95,6 +94,5 @@ namespace Meadow.Foundation.Motors
 
             //
         }
-
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/RTCs.DS323x/Driver/RTCs.DS323x/DS3231.cs
+++ b/Source/Meadow.Foundation.Peripherals/RTCs.DS323x/Driver/RTCs.DS323x/DS3231.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.RTCs
@@ -15,7 +16,7 @@ namespace Meadow.Foundation.RTCs
         /// <param name="i2cBus">The I2C Bus the peripheral is connected to</param>
         /// <param name="address">I2C Bus address of the peripheral</param>
         public Ds3231(
-            IIODevice device,
+            IMeadowDevice device,
             II2cBus i2cBus,
             IPin interruptPin = null,
             byte address = 0x68)

--- a/Source/Meadow.Foundation.Peripherals/RTCs.DS323x/Driver/RTCs.DS323x/DS3231.cs
+++ b/Source/Meadow.Foundation.Peripherals/RTCs.DS323x/Driver/RTCs.DS323x/DS3231.cs
@@ -1,4 +1,3 @@
-using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.RTCs
@@ -16,7 +15,7 @@ namespace Meadow.Foundation.RTCs
         /// <param name="i2cBus">The I2C Bus the peripheral is connected to</param>
         /// <param name="address">I2C Bus address of the peripheral</param>
         public Ds3231(
-            IMeadowDevice device,
+            IDigitalInputController device,
             II2cBus i2cBus,
             IPin interruptPin = null,
             byte address = 0x68)

--- a/Source/Meadow.Foundation.Peripherals/RTCs.DS323x/Driver/RTCs.DS323x/DS323x.cs
+++ b/Source/Meadow.Foundation.Peripherals/RTCs.DS323x/Driver/RTCs.DS323x/DS323x.cs
@@ -1,6 +1,7 @@
-using System;
+using Meadow.Devices;
 using Meadow.Foundation.Helpers;
 using Meadow.Hardware;
+using System;
 
 namespace Meadow.Foundation.RTCs
 {
@@ -158,7 +159,7 @@ namespace Meadow.Foundation.RTCs
         private AlarmRaised _alarm2Delegate;
         private bool _interruptCreatedInternally;
 
-        protected Ds323x(I2cPeripheral peripheral, IIODevice device, IPin interruptPin)
+        protected Ds323x(I2cPeripheral peripheral, IMeadowDevice device, IPin interruptPin)
         {
             ds323x = peripheral;
 

--- a/Source/Meadow.Foundation.Peripherals/RTCs.DS323x/Driver/RTCs.DS323x/DS323x.cs
+++ b/Source/Meadow.Foundation.Peripherals/RTCs.DS323x/Driver/RTCs.DS323x/DS323x.cs
@@ -1,4 +1,3 @@
-using Meadow.Devices;
 using Meadow.Foundation.Helpers;
 using Meadow.Hardware;
 using System;
@@ -159,7 +158,7 @@ namespace Meadow.Foundation.RTCs
         private AlarmRaised _alarm2Delegate;
         private bool _interruptCreatedInternally;
 
-        protected Ds323x(I2cPeripheral peripheral, IMeadowDevice device, IPin interruptPin)
+        protected Ds323x(I2cPeripheral peripheral, IDigitalInputController device, IPin interruptPin)
         {
             ds323x = peripheral;
 

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Camera.ArducamMini/Driver/Sensors.Camera.ArducamMini/ArducamMini.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Camera.ArducamMini/Driver/Sensors.Camera.ArducamMini/ArducamMini.cs
@@ -1,7 +1,8 @@
-﻿using System.Threading;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 using System.IO;
-using Meadow.Hardware;
+using System.Threading;
 
 namespace Meadow.Foundation.Sensors.Camera
 {
@@ -34,8 +35,6 @@ namespace Meadow.Foundation.Sensors.Camera
 
         readonly byte Address = 0x30;
 
-        
-
         public int DEFAULT_SPEED => 8000; // in khz
 
         protected II2cPeripheral i2cDevice;
@@ -44,9 +43,7 @@ namespace Meadow.Foundation.Sensors.Camera
 
         protected IDigitalOutputPort chipSelectPort;
 
-        
-
-        public ArducamMini(IIODevice device, ISpiBus spiBus, IPin chipSelectPin, II2cBus i2cBus, byte address = 0x30)
+        public ArducamMini(IMeadowDevice device, ISpiBus spiBus, IPin chipSelectPin, II2cBus i2cBus, byte address = 0x30)
         {
             i2cDevice = new I2cPeripheral(i2cBus, address);
 
@@ -56,10 +53,6 @@ namespace Meadow.Foundation.Sensors.Camera
 
             Initialize();
         }
-
-        
-
-        
 
         private void Cbi(ref int reg, int bitmask)
         {
@@ -204,7 +197,5 @@ namespace Meadow.Foundation.Sensors.Camera
             var temp = ReadSpiRegister(address);
             WriteSpiRegister(address, (byte)(temp & (~bit)));
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Camera.ArducamMini/Samples/Sensors.Camera.ArducamMini_Display_Sample/Sensors.Camera.ArducamMini_Display_Sample.csproj
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Camera.ArducamMini/Samples/Sensors.Camera.ArducamMini_Display_Sample/Sensors.Camera.ArducamMini_Display_Sample.csproj
@@ -5,8 +5,8 @@
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meadow.Foundation.Sensors.Motion.ArducamMini" Version="0.1.0" />
     <ProjectReference Include="..\..\..\..\Meadow.Foundation.Peripherals\Displays.TftSpi\Driver\Displays.TFTSPI\Displays.TftSpi.csproj" />
     <ProjectReference Include="..\..\..\..\Meadow.Foundation.Libraries_and_Frameworks\Graphics\MicroGraphics\Driver\Graphics.MicroGraphics\MicroGraphics.csproj" />
+    <ProjectReference Include="..\..\Driver\Sensors.Camera.ArducamMini\Sensors.Camera.ArducamMini.csproj" />
   </ItemGroup>
 </Project>

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Camera.ArducamMini/Samples/Sensors.Camera.ArucamMini_Sample/Sensors.Camera.ArucamMini_Sample.csproj
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Camera.ArducamMini/Samples/Sensors.Camera.ArucamMini_Sample/Sensors.Camera.ArucamMini_Sample.csproj
@@ -5,6 +5,6 @@
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meadow.Foundation.Sensors.Motion.ArducamMini" Version="0.1.0" />
+    <ProjectReference Include="..\..\Driver\Sensors.Camera.ArducamMini\Sensors.Camera.ArducamMini.csproj" />
   </ItemGroup>
 </Project>

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Camera.VC0706/Driver/Sensors.Camera.VC0706/ICamera.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Camera.VC0706/Driver/Sensors.Camera.VC0706/ICamera.cs
@@ -1,5 +1,6 @@
 ﻿namespace Meadow.Foundation.Sensors.Camera
 {
+    //TODO: empty interface
     public interface ICamera
     {
         

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Camera.VC0706/Driver/Sensors.Camera.VC0706/VC0706.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Camera.VC0706/Driver/Sensors.Camera.VC0706/VC0706.cs
@@ -1,5 +1,4 @@
-﻿using Meadow.Devices;
-using Meadow.Hardware;
+﻿using Meadow.Hardware;
 using System;
 using System.Text;
 using System.Threading;
@@ -73,7 +72,7 @@ namespace Meadow.Foundation.Sensors.Camera
         byte bufferLen;
         ushort frameptr;
 
-        public Vc0706(IMeadowDevice device, SerialPortName portName, int baud)
+        public Vc0706(ISerialController device, SerialPortName portName, int baud)
         {
              serialPort = device.CreateSerialPort(portName, baud);
             /*serialPort = device.CreateSerialMessagePort(

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Camera.VC0706/Driver/Sensors.Camera.VC0706/VC0706.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Camera.VC0706/Driver/Sensors.Camera.VC0706/VC0706.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 using System.Text;
 using System.Threading;
@@ -26,7 +27,6 @@ namespace Meadow.Foundation.Sensors.Camera
         static byte MOTION_STATUS = 0x43;
         static byte TVOUT_CTRL = 0x44;
         static byte OSD_ADD_CHAR = 0x45;
-        
 
         static byte STOPCURRENTFRAME = 0x0;
         static byte STOPNEXTFRAME = 0x1;
@@ -73,9 +73,7 @@ namespace Meadow.Foundation.Sensors.Camera
         byte bufferLen;
         ushort frameptr;
 
-        
-
-        public Vc0706(IIODevice device, SerialPortName portName, int baud)
+        public Vc0706(IMeadowDevice device, SerialPortName portName, int baud)
         {
              serialPort = device.CreateSerialPort(portName, baud);
             /*serialPort = device.CreateSerialMessagePort(
@@ -103,8 +101,6 @@ namespace Meadow.Foundation.Sensors.Camera
                     break;
             }
         }
-
-        
 
         bool Reset()
         {

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.GP2D12/Driver/Sensors.Distance.GP2D12/GP2D12.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.GP2D12/Driver/Sensors.Distance.GP2D12/GP2D12.cs
@@ -1,8 +1,7 @@
-﻿using Meadow.Devices;
+﻿using System;
+using System.Threading.Tasks;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Distance;
-using System;
-using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Distance
 {
@@ -21,7 +20,7 @@ namespace Meadow.Foundation.Sensors.Distance
 
         public DistanceConditions Conditions => throw new NotImplementedException();
 
-        public Gp2D12(IMeadowDevice device, IPin analogInputPin)
+        public Gp2D12(IAnalogInputController device, IPin analogInputPin)
         {
             analogInputPort = device.CreateAnalogInputPort(analogInputPin);
             analogInputPort.Changed += AnalogInputPort_Changed;

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.GP2D12/Driver/Sensors.Distance.GP2D12/GP2D12.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.GP2D12/Driver/Sensors.Distance.GP2D12/GP2D12.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Threading.Tasks;
-using Meadow;
+﻿using Meadow.Devices;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Distance;
+using System;
+using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Distance
 {
@@ -21,11 +21,7 @@ namespace Meadow.Foundation.Sensors.Distance
 
         public DistanceConditions Conditions => throw new NotImplementedException();
 
-        
-
-        
-
-        public Gp2D12(IIODevice device, IPin analogInputPin)
+        public Gp2D12(IMeadowDevice device, IPin analogInputPin)
         {
             analogInputPort = device.CreateAnalogInputPort(analogInputPin);
             analogInputPort.Changed += AnalogInputPort_Changed;
@@ -36,10 +32,6 @@ namespace Meadow.Foundation.Sensors.Distance
             CurrentDistance = 26 / e.New;
             DistanceDetected?.Invoke(this, new DistanceEventArgs(CurrentDistance));
         }
-
-        
-
-        
 
         public async Task<float> ReadDistance()
         {
@@ -57,7 +49,5 @@ namespace Meadow.Foundation.Sensors.Distance
         {
             throw new NotImplementedException();
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Hcsr04/Driver/Sensors.Distance.HCSR04/HCSR04.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Hcsr04/Driver/Sensors.Distance.HCSR04/HCSR04.cs
@@ -1,8 +1,7 @@
-using Meadow.Devices;
-using Meadow.Hardware;
-using Meadow.Peripherals.Sensors.Distance;
 using System;
 using System.Threading;
+using Meadow.Hardware;
+using Meadow.Peripherals.Sensors.Distance;
 
 namespace Meadow.Foundation.Sensors.Distance
 {
@@ -51,7 +50,7 @@ namespace Meadow.Foundation.Sensors.Distance
         /// </summary>
         /// <param name="triggerPin"></param>
         /// <param name="echoPin"></param>
-        public Hcsr04(IMeadowDevice device, IPin triggerPin, IPin echoPin) :
+        public Hcsr04(IDigitalInputOutputController device, IPin triggerPin, IPin echoPin) :
             this (device.CreateDigitalOutputPort(triggerPin, false), 
                   device.CreateDigitalInputPort(echoPin, InterruptMode.EdgeBoth)) { }
 

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Hcsr04/Driver/Sensors.Distance.HCSR04/HCSR04.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Hcsr04/Driver/Sensors.Distance.HCSR04/HCSR04.cs
@@ -1,3 +1,4 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Distance;
 using System;
@@ -10,8 +11,6 @@ namespace Meadow.Foundation.Sensors.Distance
     /// </summary>
     public class Hcsr04 : IRangeFinder
     {
-        
-
         /// <summary>
         /// Returns current distance detected in cm.
         /// </summary>
@@ -35,10 +34,6 @@ namespace Meadow.Foundation.Sensors.Distance
         public event EventHandler<DistanceEventArgs> DistanceDetected = delegate { };
         public event EventHandler<DistanceConditionChangeResult> Updated;
 
-        
-
-        
-
         /// <summary>
         /// Trigger Pin.
         /// </summary>
@@ -51,16 +46,12 @@ namespace Meadow.Foundation.Sensors.Distance
 
         protected long tickStart;
 
-        
-
-        
-
         /// <summary>
         /// Create a new HCSR04 object with an IO Device
         /// </summary>
         /// <param name="triggerPin"></param>
         /// <param name="echoPin"></param>
-        public Hcsr04(IIODevice device, IPin triggerPin, IPin echoPin) :
+        public Hcsr04(IMeadowDevice device, IPin triggerPin, IPin echoPin) :
             this (device.CreateDigitalOutputPort(triggerPin, false), 
                   device.CreateDigitalInputPort(echoPin, InterruptMode.EdgeBoth)) { }
 
@@ -76,8 +67,6 @@ namespace Meadow.Foundation.Sensors.Distance
             this.echoPort = echoPort;
             this.echoPort.Changed += OnEchoPortChanged;
         }
-
-        
 
         /// <summary>
         /// Sends a trigger signal

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Hysrf05/Driver/Sensors.Distance.HYSRF05/HYSRF05.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Hysrf05/Driver/Sensors.Distance.HYSRF05/HYSRF05.cs
@@ -1,7 +1,8 @@
-using System;
-using System.Threading;
+using Meadow.Devices;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Distance;
+using System;
+using System.Threading;
 
 namespace Meadow.Foundation.Sensors.Distance
 {
@@ -10,8 +11,6 @@ namespace Meadow.Foundation.Sensors.Distance
     /// </summary>
     public class Hysrf05 : IRangeFinder
     {
-        
-
         /// <summary>
         /// Returns current distance detected in cm.
         /// </summary>
@@ -35,10 +34,6 @@ namespace Meadow.Foundation.Sensors.Distance
         public event EventHandler<DistanceEventArgs> DistanceDetected;
         public event EventHandler<DistanceConditionChangeResult> Updated;
 
-        
-
-        
-
         /// <summary>
         /// Trigger Pin.
         /// </summary>
@@ -51,10 +46,6 @@ namespace Meadow.Foundation.Sensors.Distance
 
         protected long tickStart;
 
-        
-
-        
-
         /// <summary>
         /// Create a new HYSRF05 object with a IO Device
         /// HSSRF05 must be running the default 4/5 pin mode
@@ -62,7 +53,7 @@ namespace Meadow.Foundation.Sensors.Distance
         /// </summary>
         /// <param name="triggerPin"></param>
         /// <param name="echoPin"></param>
-        public Hysrf05(IIODevice device, IPin triggerPin, IPin echoPin) :
+        public Hysrf05(IMeadowDevice device, IPin triggerPin, IPin echoPin) :
             this(device.CreateDigitalOutputPort(triggerPin, false),
                 device.CreateDigitalInputPort(echoPin, InterruptMode.EdgeBoth)) { }
 
@@ -80,8 +71,6 @@ namespace Meadow.Foundation.Sensors.Distance
             this.echoPort = echoPort;
             this.echoPort.Changed += OnEchoPortChanged;
         }
-
-        
 
         /// <summary>
         /// Sends a trigger signal

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Hysrf05/Driver/Sensors.Distance.HYSRF05/HYSRF05.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Hysrf05/Driver/Sensors.Distance.HYSRF05/HYSRF05.cs
@@ -1,8 +1,7 @@
-using Meadow.Devices;
-using Meadow.Hardware;
-using Meadow.Peripherals.Sensors.Distance;
 using System;
 using System.Threading;
+using Meadow.Hardware;
+using Meadow.Peripherals.Sensors.Distance;
 
 namespace Meadow.Foundation.Sensors.Distance
 {
@@ -53,7 +52,7 @@ namespace Meadow.Foundation.Sensors.Distance
         /// </summary>
         /// <param name="triggerPin"></param>
         /// <param name="echoPin"></param>
-        public Hysrf05(IMeadowDevice device, IPin triggerPin, IPin echoPin) :
+        public Hysrf05(IDigitalInputOutputController device, IPin triggerPin, IPin echoPin) :
             this(device.CreateDigitalOutputPort(triggerPin, false),
                 device.CreateDigitalInputPort(echoPin, InterruptMode.EdgeBoth)) { }
 

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Mb10x0/Driver/Sensors.Distance.Mb10x0/Mb10x0.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Mb10x0/Driver/Sensors.Distance.Mb10x0/Mb10x0.cs
@@ -1,6 +1,5 @@
-﻿using Meadow.Devices;
+﻿using System;
 using Meadow.Hardware;
-using System;
 
 namespace Meadow.Foundation.Sensors.Distance
 {
@@ -10,7 +9,7 @@ namespace Meadow.Foundation.Sensors.Distance
 
         public int Baud => 9600;
 
-        public Mb10x0(IMeadowDevice device, SerialPortName portName)
+        public Mb10x0(ISerialController device, SerialPortName portName)
         {
             serialPort = device.CreateSerialPort(portName, Baud);
             serialPort.Open();

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Mb10x0/Driver/Sensors.Distance.Mb10x0/Mb10x0.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Mb10x0/Driver/Sensors.Distance.Mb10x0/Mb10x0.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 
 namespace Meadow.Foundation.Sensors.Distance
@@ -9,7 +10,7 @@ namespace Meadow.Foundation.Sensors.Distance
 
         public int Baud => 9600;
 
-        public Mb10x0(IIODevice device, SerialPortName portName)
+        public Mb10x0(IMeadowDevice device, SerialPortName portName)
         {
             serialPort = device.CreateSerialPort(portName, Baud);
             serialPort.Open();

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Sfsr02/Driver/Sensors.Distance.SFSR02/SFSR02.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Sfsr02/Driver/Sensors.Distance.SFSR02/SFSR02.cs
@@ -1,8 +1,7 @@
-﻿using Meadow.Devices;
+﻿using System;
+using System.Threading;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Distance;
-using System;
-using System.Threading;
 
 namespace Meadow.Foundation.Sensors.Distance
 {
@@ -43,7 +42,7 @@ namespace Meadow.Foundation.Sensors.Distance
         /// </summary>
         /// <param name="triggerEchoPin"></param>
         /// <param name="device"></param>
-        public Sfsr02(IMeadowDevice device, IPin triggerEchoPin) :
+        public Sfsr02(IBiDirectionalController device, IPin triggerEchoPin) :
             this(device.CreateBiDirectionalPort(triggerEchoPin, false))
         { }
 

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Sfsr02/Driver/Sensors.Distance.SFSR02/SFSR02.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Sfsr02/Driver/Sensors.Distance.SFSR02/SFSR02.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Distance;
 using System;
 using System.Threading;
@@ -7,8 +8,6 @@ namespace Meadow.Foundation.Sensors.Distance
 {
     public class Sfsr02 : IRangeFinder
     {
-        
-
         /// <summary>
         /// Returns current distance detected in cm.
         /// </summary>
@@ -32,10 +31,6 @@ namespace Meadow.Foundation.Sensors.Distance
         public event EventHandler<DistanceEventArgs> DistanceDetected;
         public event EventHandler<DistanceConditionChangeResult> Updated;
 
-        
-
-        
-
         /// <summary>
         /// Trigger/Echo Pin
         /// </summary>
@@ -43,16 +38,12 @@ namespace Meadow.Foundation.Sensors.Distance
 
         protected long tickStart;
 
-        
-
-        
-
         /// <summary>
         /// Create a new SFSR02 object with an IO Device
         /// </summary>
         /// <param name="triggerEchoPin"></param>
         /// <param name="device"></param>
-        public Sfsr02(IIODevice device, IPin triggerEchoPin) :
+        public Sfsr02(IMeadowDevice device, IPin triggerEchoPin) :
             this(device.CreateBiDirectionalPort(triggerEchoPin, false))
         { }
 
@@ -66,8 +57,6 @@ namespace Meadow.Foundation.Sensors.Distance
 
             this.triggerEchoPort.Changed += OnEchoPortChanged;
         }
-
-        
 
         /// <summary>
         /// Sends a trigger signal

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Vl53l0x/Driver/Sensors.Distance.Vl53l0x/VL53L0X.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Vl53l0x/Driver/Sensors.Distance.Vl53l0x/VL53L0X.cs
@@ -1,9 +1,8 @@
-﻿using Meadow.Devices;
-using Meadow.Hardware;
-using Meadow.Peripherals.Sensors.Distance;
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Meadow.Hardware;
+using Meadow.Peripherals.Sensors.Distance;
 
 namespace Meadow.Foundation.Sensors.Distance
 {
@@ -129,7 +128,7 @@ namespace Meadow.Foundation.Sensors.Distance
 
         public event EventHandler<DistanceConditionChangeResult> Updated;
 
-        public Vl53l0x(IMeadowDevice device, II2cBus i2cBus, byte address = DefaultI2cAddress, UnitType units = UnitType.mm) : 
+        public Vl53l0x(IDigitalOutputController device, II2cBus i2cBus, byte address = DefaultI2cAddress, UnitType units = UnitType.mm) : 
             this (device, i2cBus, null, address, units)
         {
         }
@@ -137,7 +136,7 @@ namespace Meadow.Foundation.Sensors.Distance
         /// <param name="i2cBus">I2C bus</param>
         /// <param name="address">VL53L0X address</param>
         /// <param name="units">Unit of measure</param>
-        public Vl53l0x(IMeadowDevice device, II2cBus i2cBus, IPin shutdownPin, byte address = DefaultI2cAddress,  UnitType units = UnitType.mm)
+        public Vl53l0x(IDigitalOutputController device, II2cBus i2cBus, IPin shutdownPin, byte address = DefaultI2cAddress,  UnitType units = UnitType.mm)
         {
             i2cPeripheral = new I2cPeripheral(i2cBus, address);
 

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Vl53l0x/Driver/Sensors.Distance.Vl53l0x/VL53L0X.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.Vl53l0x/Driver/Sensors.Distance.Vl53l0x/VL53L0X.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Distance;
 using System;
 using System.Threading;
@@ -72,8 +73,6 @@ namespace Meadow.Foundation.Sensors.Distance
         protected const int VcselPeriodPreRange = 0;
         protected const int VcselPeriodFinalRange = 1;
 
-        
-
         public enum UnitType
         {
             mm,
@@ -130,7 +129,7 @@ namespace Meadow.Foundation.Sensors.Distance
 
         public event EventHandler<DistanceConditionChangeResult> Updated;
 
-        public Vl53l0x(IIODevice device, II2cBus i2cBus, byte address = DefaultI2cAddress, UnitType units = UnitType.mm) : 
+        public Vl53l0x(IMeadowDevice device, II2cBus i2cBus, byte address = DefaultI2cAddress, UnitType units = UnitType.mm) : 
             this (device, i2cBus, null, address, units)
         {
         }
@@ -138,7 +137,7 @@ namespace Meadow.Foundation.Sensors.Distance
         /// <param name="i2cBus">I2C bus</param>
         /// <param name="address">VL53L0X address</param>
         /// <param name="units">Unit of measure</param>
-        public Vl53l0x(IIODevice device, II2cBus i2cBus, IPin shutdownPin, byte address = DefaultI2cAddress,  UnitType units = UnitType.mm)
+        public Vl53l0x(IMeadowDevice device, II2cBus i2cBus, IPin shutdownPin, byte address = DefaultI2cAddress,  UnitType units = UnitType.mm)
         {
             i2cPeripheral = new I2cPeripheral(i2cBus, address);
 

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Light.Alspt19315C/Driver/Sensors.Light.Alspt19315C/Alspt19315C.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Light.Alspt19315C/Driver/Sensors.Light.Alspt19315C/Alspt19315C.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Light
@@ -22,7 +23,7 @@ namespace Meadow.Foundation.Sensors.Light
         ///     Create a new light sensor object using a static reference voltage.
         /// </summary>
         /// <param name="pin">AnalogChannel connected to the sensor.</param>
-        public Alspt19315C(IIODevice device, IPin pin)
+        public Alspt19315C(IMeadowDevice device, IPin pin)
         {
             sensor = device.CreateAnalogInputPort(pin);
         }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Light.Alspt19315C/Driver/Sensors.Light.Alspt19315C/Alspt19315C.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Light.Alspt19315C/Driver/Sensors.Light.Alspt19315C/Alspt19315C.cs
@@ -1,9 +1,9 @@
-﻿using Meadow.Devices;
+﻿using System.Threading.Tasks;
 using Meadow.Hardware;
-using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Light
 {
+    //TODO: this class needs the StartUpdating/StopUpdating/IOBservable pattern
     public class Alspt19315C
     {
         /// <summary>
@@ -23,7 +23,7 @@ namespace Meadow.Foundation.Sensors.Light
         ///     Create a new light sensor object using a static reference voltage.
         /// </summary>
         /// <param name="pin">AnalogChannel connected to the sensor.</param>
-        public Alspt19315C(IMeadowDevice device, IPin pin)
+        public Alspt19315C(IAnalogInputController device, IPin pin)
         {
             sensor = device.CreateAnalogInputPort(pin);
         }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Light.Temt6000/Driver/Sensors.Light.Temt6000/Temt6000.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Light.Temt6000/Driver/Sensors.Light.Temt6000/Temt6000.cs
@@ -1,9 +1,9 @@
-﻿using Meadow.Devices;
+﻿using System.Threading.Tasks;
 using Meadow.Hardware;
-using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Light
 {
+    //TODO: this class needs the StartUpdating/StopUpdating/IOBservable pattern
     public class Temt6000
     {
         /// <summary>
@@ -23,7 +23,7 @@ namespace Meadow.Foundation.Sensors.Light
         /// Create a new light sensor object using a static reference voltage.
         /// </summary>
         /// <param name="pin">AnalogChannel connected to the sensor.</param>
-        public Temt6000(IMeadowDevice device, IPin pin)
+        public Temt6000(IAnalogInputController device, IPin pin)
         {
             sensor = device.CreateAnalogInputPort(pin);
         }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Light.Temt6000/Driver/Sensors.Light.Temt6000/Temt6000.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Light.Temt6000/Driver/Sensors.Light.Temt6000/Temt6000.cs
@@ -1,38 +1,31 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Light
 {
     public class Temt6000
     {
-        
-
         /// <summary>
-        ///     Analog port connected to the sensor.
+        /// Analog port connected to the sensor.
         /// </summary>
         private readonly IAnalogInputPort sensor;
 
         /// <summary>
-        ///     Voltage being output by the sensor.
+        /// Voltage being output by the sensor.
         /// </summary>
         public Task<float> GetVoltage()
         {
             return sensor.Read();
         }
 
-        
-
-        
-
         /// <summary>
-        ///     Create a new light sensor object using a static reference voltage.
+        /// Create a new light sensor object using a static reference voltage.
         /// </summary>
         /// <param name="pin">AnalogChannel connected to the sensor.</param>
-        public Temt6000(IIODevice device, IPin pin)
+        public Temt6000(IMeadowDevice device, IPin pin)
         {
             sensor = device.CreateAnalogInputPort(pin);
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Light.Tsl2561/Driver/Sensors.Light.TSL2561/TSL2561.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Light.Tsl2561/Driver/Sensors.Light.TSL2561/TSL2561.cs
@@ -1,48 +1,43 @@
-﻿using System;
-using System.Threading;
+﻿using Meadow.Devices;
 using Meadow.Hardware;
+using System;
+using System.Threading;
 
 namespace Meadow.Foundation.Sensors.Light
 {
     /// <summary>
-    ///     Driver for the TSL2561 light-to-digital converter.
+    /// Driver for the TSL2561 light-to-digital converter.
     /// </summary>
     public class Tsl2561 : IDisposable //, ILightSensor
     {
-        
-
         /// <summary>
-        ///     The command bit in the Command Register.
-        ///     See page 13 of the datasheet.
+        /// The command bit in the Command Register.
+        /// See page 13 of the datasheet.
         /// </summary>
         private const byte CommandBit = 0x80;
 
         /// <summary>
-        ///     The interrupt clear bit in the Command Register.
-        ///     See page 13 of the datasheet.
+        /// The interrupt clear bit in the Command Register.
+        /// See page 13 of the datasheet.
         /// </summary>
         private const byte ClearInterruptBit = 0xC0;
 
         /// <summary>
-        ///     This bit control the write operations for the TSL2561.  Setting
-        ///     this bit puts the chip into Word mode for the specified register.
+        /// This bit control the write operations for the TSL2561.  Setting
+        /// this bit puts the chip into Word mode for the specified register.
         /// </summary>
         /// <remarks>
-        ///     See page 13 of the data sheet.
+        /// See page 13 of the data sheet.
         /// </remarks>
         private const byte WordModeBit = 0x20;
 
         /// <summary>
-        ///     Minimum value that should be used for the polling frequency.
+        /// Minimum value that should be used for the polling frequency.
         /// </summary>
         public const ushort MinimumPollingPeriod = 100;
         
-        
-
-        
-
         /// <summary>
-        ///     Valid addresses for the sensor.
+        /// Valid addresses for the sensor.
         /// </summary>
         public enum Addresses : byte
         {
@@ -52,11 +47,11 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Integration timing.
-        ///     See Timing Register on page 14 of the data sheet.
+        /// Integration timing.
+        /// See Timing Register on page 14 of the data sheet.
         /// </summary>
         /// <remarks>
-        ///     Valid integration times are 13.7ms, 101ms, 402ms and Manual.
+        /// Valid integration times are 13.7ms, 101ms, 402ms and Manual.
         /// </remarks>
         public enum IntegrationTiming : byte
         {
@@ -67,11 +62,11 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Possible gain setting for the sensor.
-        ///     See Timing Register on page 14 of the data sheet.
+        /// Possible gain setting for the sensor.
+        /// See Timing Register on page 14 of the data sheet.
         /// </summary>
         /// <remarks>
-        ///     Possible gain values are low (x1) and high (x16).
+        /// Possible gain values are low (x1) and high (x16).
         /// </remarks>
         public enum Gain
         {
@@ -80,8 +75,8 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Determine if interrupts are enabled or not.
-        ///     See Interrupt Control Register on page 15 of the datasheet.
+        /// Determine if interrupts are enabled or not.
+        /// See Interrupt Control Register on page 15 of the datasheet.
         /// </summary>
         public enum InterruptMode : byte
         {
@@ -89,19 +84,15 @@ namespace Meadow.Foundation.Sensors.Light
             Enable
         }
 
-        
-
-        
-
         /// <summary>
-        ///     TSL2561 register locations.
-        ///     See Register Set on page 12 and Command Register on page 13 of the datasheet.
+        /// TSL2561 register locations.
+        /// See Register Set on page 12 and Command Register on page 13 of the datasheet.
         /// </summary>
         /// <remarks>
-        ///     All of the register numbers have 0x80 added to the register.  When reading
-        ///     or witing to a register the application must set the CMD bit in the command
-        ///     register (see page 13) and the register address is written into the lower
-        ///     four bits of the Command Register.
+        /// All of the register numbers have 0x80 added to the register.  When reading
+        /// or witing to a register the application must set the CMD bit in the command
+        /// register (see page 13) and the register address is written into the lower
+        /// four bits of the Command Register.
         /// </remarks>
         private static class Registers
         {
@@ -115,26 +106,18 @@ namespace Meadow.Foundation.Sensors.Light
             public static readonly byte Data1 = 0x8e;
         }
 
-        
-
-        
-
         /// <summary>
-        ///     GPIO pin on that is connected to the interrupt pin on the TSL2561.
+        /// GPIO pin on that is connected to the interrupt pin on the TSL2561.
         /// </summary>
         private IDigitalInputPort _interruptPin;
 
         /// <summary>
-        ///     Update interval in milliseconds
+        /// Update interval in milliseconds
         /// </summary>
         private readonly ushort updateInterval = 100;
 
-        
-
-        
-
         /// <summary>
-        ///     Implement IDisposable interface.
+        /// Implement IDisposable interface.
         /// </summary>
         public void Dispose()
         {
@@ -144,15 +127,11 @@ namespace Meadow.Foundation.Sensors.Light
             }
         }
 
-        
-
-        
-
         /// <summary>
-        ///     Get the sensor reading
+        /// Get the sensor reading
         /// </summary>
         /// <remarks>
-        ///     This can be used to get the raw sensor data from the TSL2561.
+        /// This can be used to get the raw sensor data from the TSL2561.
         /// </remarks>
         /// <returns>Sensor data.</returns>
         public ushort[] SensorReading
@@ -161,7 +140,7 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Luminosity reading from the TSL2561 sensor.
+        /// Luminosity reading from the TSL2561 sensor.
         /// </summary>
         public float Luminosity
         {
@@ -180,12 +159,12 @@ namespace Meadow.Foundation.Sensors.Light
         private float _lastNotifiedLux = 0.001F;
 
         /// <summary>
-        ///     ID of the sensor.
+        /// ID of the sensor.
         /// </summary>
         /// <remarks>
-        ///     The ID register (page 16 of the datasheet) gives two pieces of the information:
-        ///     Part Number: bits 4-7 (0000 = TSL2560, 0001 = TSL2561)
-        ///     Revision number: bits 0-3
+        /// The ID register (page 16 of the datasheet) gives two pieces of the information:
+        /// Part Number: bits 4-7 (0000 = TSL2560, 0001 = TSL2561)
+        /// Revision number: bits 0-3
         /// </remarks>
         public byte ID
         {
@@ -193,13 +172,13 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Gain of the sensor.
-        ///     The sensor gain can be set to high or low.
+        /// Gain of the sensor.
+        /// The sensor gain can be set to high or low.
         /// </summary>
         /// <remarks>
-        ///     The sensor Gain bit can be found in the Timing Register.  This allows the gain
-        ///     to be set to High (16x) or Low (1x).
-        ///     See page 14 of the datasheet.
+        /// The sensor Gain bit can be found in the Timing Register.  This allows the gain
+        /// to be set to High (16x) or Low (1x).
+        /// See page 14 of the datasheet.
         /// </remarks>
         public Gain SensorGain
         {
@@ -224,7 +203,7 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Integration timing for the sensor reading.
+        /// Integration timing for the sensor reading.
         /// </summary>
         public IntegrationTiming Timing
         {
@@ -252,12 +231,12 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Lower interrupt threshold.
+        /// Lower interrupt threshold.
         /// </summary>
         /// <remarks>
-        ///     Get or se the lower interrupt threshold.  Any readings below this
-        ///     value may trigger an interrupt <seealso cref="SetInterruptMode" />
-        ///     See page 14/15 of the datasheet.
+        /// Get or se the lower interrupt threshold.  Any readings below this
+        /// value may trigger an interrupt <seealso cref="SetInterruptMode" />
+        /// See page 14/15 of the datasheet.
         /// </remarks>
         public ushort ThresholdLow
         {
@@ -269,12 +248,12 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     High interrupt threshold.
+        /// High interrupt threshold.
         /// </summary>
         /// <remarks>
-        ///     Get or se the upper interrupt threshold.  Any readings above this
-        ///     value may trigger an interrupt <seealso cref="SetInterruptMode" />
-        ///     See page 14/15 of the datasheet.
+        /// Get or se the upper interrupt threshold.  Any readings above this
+        /// value may trigger an interrupt <seealso cref="SetInterruptMode" />
+        /// See page 14/15 of the datasheet.
         /// </remarks>
         public ushort ThresholdHigh
         {
@@ -286,57 +265,49 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Changes in light level greater than this value will generate an interrupt
-        ///     in auto-update mode.
+        /// Changes in light level greater than this value will generate an interrupt
+        /// in auto-update mode.
         /// </summary>
         public float LightLevelChangeNotificationThreshold { get; set; } = 0.001F;
 
         /// <summary>
-        ///     ICommunicationBus object used to communicate with the sensor.
+        /// ICommunicationBus object used to communicate with the sensor.
         /// </summary>
         /// <remarks>
-        ///     In this case the actual object will always be an I2SBus object.
+        /// In this case the actual object will always be an I2SBus object.
         /// </remarks>
         private readonly II2cPeripheral tsl2561;
 
-        
-
-        
-
         /// <summary>
-        ///     Allow the user to attach an interrupt to the TSL2561.
+        /// Allow the user to attach an interrupt to the TSL2561.
         /// </summary>
         /// <remarks>
-        ///     This interrupt requires the interrupts to be set up correctly.
-        ///     <see cref="SetInterruptMode" />
+        /// This interrupt requires the interrupts to be set up correctly.
+        /// <see cref="SetInterruptMode" />
         /// </remarks>
         /// <param name="time">Date and time the interrupt was generated.</param>
         public delegate void ThresholdInterrupt(DateTime time);
 
         /// <summary>
-        ///     Interrupt generated when the reading is outside of the threshold window.
+        /// Interrupt generated when the reading is outside of the threshold window.
         /// </summary>
         /// <remarks>
-        ///     This interrupt requires the threshold window to be defined <see cref="SetInterruptMode" />
-        ///     and for the interrupts to be enabled.
+        /// This interrupt requires the threshold window to be defined <see cref="SetInterruptMode" />
+        /// and for the interrupts to be enabled.
         /// </remarks>
         public event ThresholdInterrupt ReadingOutsideThresholdWindow;
 
         /// <summary>
-        ///     Event raised when the temperature change is greater than the 
-        ///     TemperatureChangeNotificationThreshold value.
+        /// Event raised when the temperature change is greater than the 
+        /// TemperatureChangeNotificationThreshold value.
         /// </summary>
         public event EventHandler<float> LightLevelChanged = delegate { };
 
-        
-
-        
-
         /// <summary>
-        ///     Create a new instance of the TSL2561 class with the specified I2C address.
+        /// Create a new instance of the TSL2561 class with the specified I2C address.
         /// </summary>
         /// <remarks>
-        ///     By default the sensor will be set to low gain.
+        /// By default the sensor will be set to low gain.
         /// <remarks>
         /// <param name="address">I2C address of the TSL2561</param>
         /// <param name="i2cBus">I2C bus (default = 100 KHz).</param>
@@ -369,12 +340,8 @@ namespace Meadow.Foundation.Sensors.Light
             }
         }
 
-        
-
-        
-
         /// <summary>
-        ///     Start the update process.
+        /// Start the update process.
         /// </summary>
         private void StartUpdating()
         {
@@ -389,7 +356,7 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Update the Luminosity reading.
+        /// Update the Luminosity reading.
         /// </summary>
         public void Update()
         {
@@ -463,10 +430,10 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Turn the TSL2561 off.
+        /// Turn the TSL2561 off.
         /// </summary>
         /// <remarks>
-        ///     Reset the power bits in the control register (page 13 of the datasheet).
+        /// Reset the power bits in the control register (page 13 of the datasheet).
         /// </remarks>
         public void TurnOff()
         {
@@ -474,10 +441,10 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Turn the TSL2561 on.
+        /// Turn the TSL2561 on.
         /// </summary>
         /// <remarks>
-        ///     Set the power bits in the control register (page 13 of the datasheet).
+        /// Set the power bits in the control register (page 13 of the datasheet).
         /// </remarks>
         public void TurnOn()
         {
@@ -485,12 +452,12 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Clear the interrupt flag.
-        ///     Se Command Register on page 13 of the datasheet.
+        /// Clear the interrupt flag.
+        /// Se Command Register on page 13 of the datasheet.
         /// </summary>
         /// <remarks>
-        ///     According to the datasheet, writing a 1 into bit 6 of the command
-        ///     register will clear any pending interrupts.
+        /// According to the datasheet, writing a 1 into bit 6 of the command
+        /// register will clear any pending interrupts.
         /// </remarks>
         public void ClearInterrupt()
         {
@@ -502,7 +469,7 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Put the sensor into manual integration mode.
+        /// Put the sensor into manual integration mode.
         /// </summary>
         public void ManualStart()
         {
@@ -514,7 +481,7 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Turn off manual integration mode.
+        /// Turn off manual integration mode.
         /// </summary>
         public void ManualStop()
         {
@@ -524,20 +491,20 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Turn interrupts on or off and set the conversion trigger count.
+        /// Turn interrupts on or off and set the conversion trigger count.
         /// </summary>
         /// <remarks>
-        ///     The conversion count is the number of conversions that must be outside
-        ///     of the upper and lower limits before and interrupt is generated.
-        ///     See Interrupt Control Register on page 15 and 16 of the datasheet.
+        /// The conversion count is the number of conversions that must be outside
+        /// of the upper and lower limits before and interrupt is generated.
+        /// See Interrupt Control Register on page 15 and 16 of the datasheet.
         /// </remarks>
         /// <param name="mode"></param>
         /// <param name="conversionCount">
-        ///     Number of conversions that must be outside of the threshold before an interrupt is
-        ///     generated.
+        /// Number of conversions that must be outside of the threshold before an interrupt is
+        /// generated.
         /// </param>
         /// <param name="pin">GPIO pin connected to the TSL2561 interrupt pin.  Set to null to use the previously supplied pin.</param>
-        public void SetInterruptMode(IIODevice device, InterruptMode mode, byte conversionCount, IPin pin = null)
+        public void SetInterruptMode(IMeadowDevice device, InterruptMode mode, byte conversionCount, IPin pin = null)
         {
             if (conversionCount > 15)
             {
@@ -581,13 +548,11 @@ namespace Meadow.Foundation.Sensors.Light
         }
 
         /// <summary>
-        ///     Process the interrupt generated by the TSL2561.
+        /// Process the interrupt generated by the TSL2561.
         /// </summary>
         private void InterruptPin_Changed(object sender, DigitalInputPortEventArgs e)
         {
             ReadingOutsideThresholdWindow?.Invoke(DateTime.Now);
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Light.Tsl2561/Driver/Sensors.Light.TSL2561/TSL2561.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Light.Tsl2561/Driver/Sensors.Light.TSL2561/TSL2561.cs
@@ -1,7 +1,6 @@
-﻿using Meadow.Devices;
-using Meadow.Hardware;
-using System;
+﻿using System;
 using System.Threading;
+using Meadow.Hardware;
 
 namespace Meadow.Foundation.Sensors.Light
 {
@@ -490,6 +489,8 @@ namespace Meadow.Foundation.Sensors.Light
             tsl2561.WriteRegister(Registers.Timing, timing);
         }
 
+        // TODO: should this get integrated into one of the ctors? wouldn't it be nicer to
+        // setup the interrupt stuff during construction?
         /// <summary>
         /// Turn interrupts on or off and set the conversion trigger count.
         /// </summary>
@@ -504,7 +505,7 @@ namespace Meadow.Foundation.Sensors.Light
         /// generated.
         /// </param>
         /// <param name="pin">GPIO pin connected to the TSL2561 interrupt pin.  Set to null to use the previously supplied pin.</param>
-        public void SetInterruptMode(IMeadowDevice device, InterruptMode mode, byte conversionCount, IPin pin = null)
+        public void SetInterruptMode(IDigitalInputController device, InterruptMode mode, byte conversionCount, IPin pin = null)
         {
             if (conversionCount > 15)
             {

--- a/Source/Meadow.Foundation.Peripherals/Sensors.LoadCell.Hx711/Driver/Sensors.LoadCell.Hx711/Hx711.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.LoadCell.Hx711/Driver/Sensors.LoadCell.Hx711/Hx711.cs
@@ -1,7 +1,6 @@
-﻿using Meadow.Devices;
-using Meadow.Hardware;
-using System;
+﻿using System;
 using System.Threading;
+using Meadow.Hardware;
 
 namespace Meadow.Foundation.Sensors.LoadCell
 {
@@ -45,7 +44,7 @@ namespace Meadow.Foundation.Sensors.LoadCell
         /// Creates an instance of the NAU7802 Driver class
         /// </summary>
         /// <param name="bus"></param>
-        public Hx711(IMeadowDevice device, IPin sck, IPin dout)
+        public Hx711(IDigitalInputOutputController device, IPin sck, IPin dout)
         {
             this.sck = device.CreateDigitalOutputPort(sck);
             this.dout = device.CreateDigitalInputPort(dout);

--- a/Source/Meadow.Foundation.Peripherals/Sensors.LoadCell.Hx711/Driver/Sensors.LoadCell.Hx711/Hx711.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.LoadCell.Hx711/Driver/Sensors.LoadCell.Hx711/Hx711.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Threading;
+﻿using Meadow.Devices;
 using Meadow.Hardware;
+using System;
+using System.Threading;
 
 namespace Meadow.Foundation.Sensors.LoadCell
 {
@@ -44,7 +45,7 @@ namespace Meadow.Foundation.Sensors.LoadCell
         /// Creates an instance of the NAU7802 Driver class
         /// </summary>
         /// <param name="bus"></param>
-        public Hx711(IIODevice device, IPin sck, IPin dout)
+        public Hx711(IMeadowDevice device, IPin sck, IPin dout)
         {
             this.sck = device.CreateDigitalOutputPort(sck);
             this.dout = device.CreateDigitalInputPort(dout);

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Location.MediaTek/Mt3339/Driver/Sensors.Location.MediaTek.Mt3339/Mt3339.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Location.MediaTek/Mt3339/Driver/Sensors.Location.MediaTek.Mt3339/Mt3339.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Meadow.Devices;
 using Meadow.Foundation.Sensors.Location.Gnss.NmeaParsing;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Location.Gnss;
@@ -42,7 +43,7 @@ namespace Sensors.Location.MediaTek
             Init();
         }
 
-        public Mt3339( IIODevice device, SerialPortName serialPortName)
+        public Mt3339(IMeadowDevice device, SerialPortName serialPortName)
             : this(device.CreateSerialMessagePort(
                 serialPortName, suffixDelimiter: Encoding.ASCII.GetBytes("\r\n"),
                 preserveDelimiter: true, readBufferSize: 512))

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Location.MediaTek/Mt3339/Driver/Sensors.Location.MediaTek.Mt3339/Mt3339.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Location.MediaTek/Mt3339/Driver/Sensors.Location.MediaTek.Mt3339/Mt3339.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
-using Meadow.Devices;
 using Meadow.Foundation.Sensors.Location.Gnss.NmeaParsing;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Location.Gnss;
 
+// TODO: should this be `Sensors.Gnss.MediaTek`?
 namespace Sensors.Location.MediaTek
 {
     public class NmeaEventArgs
@@ -43,7 +42,7 @@ namespace Sensors.Location.MediaTek
             Init();
         }
 
-        public Mt3339(IMeadowDevice device, SerialPortName serialPortName)
+        public Mt3339(ISerialMessageController device, SerialPortName serialPortName)
             : this(device.CreateSerialMessagePort(
                 serialPortName, suffixDelimiter: Encoding.ASCII.GetBytes("\r\n"),
                 preserveDelimiter: true, readBufferSize: 512))

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Moisture.Capacitive/Driver/Sensors.Moisture.Capacitive/Capacitive.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Moisture.Capacitive/Driver/Sensors.Moisture.Capacitive/Capacitive.cs
@@ -1,8 +1,7 @@
-﻿using Meadow.Devices;
+﻿using System;
+using System.Threading.Tasks;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Moisture;
-using System;
-using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Moisture
 {
@@ -52,7 +51,7 @@ namespace Meadow.Foundation.Sensors.Moisture
         /// <param name="device"></param>
         /// <param name="analogPin"></param>
         public Capacitive(
-            IMeadowDevice device,
+            IAnalogInputController device,
             IPin analogPin,
             float minimumVoltageCalibration = 0f,
             float maximumVoltageCalibration = 3.3f) :

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Moisture.Capacitive/Driver/Sensors.Moisture.Capacitive/Capacitive.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Moisture.Capacitive/Driver/Sensors.Moisture.Capacitive/Capacitive.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Moisture;
 using System;
 using System.Threading.Tasks;
@@ -51,7 +52,7 @@ namespace Meadow.Foundation.Sensors.Moisture
         /// <param name="device"></param>
         /// <param name="analogPin"></param>
         public Capacitive(
-            IIODevice device,
+            IMeadowDevice device,
             IPin analogPin,
             float minimumVoltageCalibration = 0f,
             float maximumVoltageCalibration = 3.3f) :

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Moisture.FC28/Driver/Sensors.Moisture.FC28/FC28.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Moisture.FC28/Driver/Sensors.Moisture.FC28/FC28.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Moisture;
 using System;
 using System.Threading;
@@ -19,8 +20,6 @@ namespace Meadow.Foundation.Sensors.Moisture
         // internal thread lock
         private object _lock = new object();
         private CancellationTokenSource SamplingTokenSource;
-
-        
 
         /// <summary>
         /// Gets a value indicating whether the sensor is currently in a sampling
@@ -54,17 +53,13 @@ namespace Meadow.Foundation.Sensors.Moisture
         /// </summary>
         public float MaximumVoltageCalibration { get; set; }
 
-        
-
-        
-
         /// <summary>
         /// Creates a FC28 soil moisture sensor object with the especified analog pin, digital pin and IO device.
         /// </summary>
         /// <param name="analogPort"></param>
         /// <param name="digitalPort"></param>
         public Fc28(
-            IIODevice device,
+            IMeadowDevice device,
             IPin analogPin,
             IPin digitalPin,
             float minimumVoltageCalibration = 0f,
@@ -88,10 +83,6 @@ namespace Meadow.Foundation.Sensors.Moisture
             MinimumVoltageCalibration = minimumVoltageCalibration;
             MaximumVoltageCalibration = maximumVoltageCalibration;
         }
-
-        
-
-        
 
         /// <summary>
         /// Convenience method to get the current soil moisture. For frequent reads, use
@@ -218,7 +209,5 @@ namespace Meadow.Foundation.Sensors.Moisture
         {
             return (((toHigh - toLow) * (value - fromLow)) / (fromHigh - fromLow)) - toLow;
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl335/Driver/Sensors.Motion.Adxl335/Adxl335.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl335/Driver/Sensors.Motion.Adxl335/Adxl335.cs
@@ -1,10 +1,9 @@
-﻿using Meadow.Devices;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Meadow.Foundation.Spatial;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Motion;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Motion
 {
@@ -110,7 +109,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// <param name="xPin">Analog pin connected to the X axis output from the ADXL335 sensor.</param>
         /// <param name="yPin">Analog pin connected to the Y axis output from the ADXL335 sensor.</param>
         /// <param name="zPin">Analog pin connected to the Z axis output from the ADXL335 sensor.</param>
-        public Adxl335(IMeadowDevice device, IPin xPin, IPin yPin, IPin zPin)
+        public Adxl335(IAnalogInputController device, IPin xPin, IPin yPin, IPin zPin)
         {
             _xPort = device.CreateAnalogInputPort(xPin);
             _yPort = device.CreateAnalogInputPort(yPin);

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl335/Driver/Sensors.Motion.Adxl335/Adxl335.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl335/Driver/Sensors.Motion.Adxl335/Adxl335.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Foundation.Spatial;
+﻿using Meadow.Devices;
+using Meadow.Foundation.Spatial;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Motion;
 using System;
@@ -39,10 +40,6 @@ namespace Meadow.Foundation.Sensors.Motion
         ///     Voltage that represents 0g.  This is the supply voltage / 2.
         /// </summary>
         private float _zeroGVoltage => SupplyVoltage / 2f;
-
-        
-
-        
 
         /// <summary>
         ///     Acceleration along the X-axis.
@@ -105,15 +102,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// <value><c>true</c> if sampling; otherwise, <c>false</c>.</value>
         public bool IsSampling { get; protected set; } = false;
 
-        
-
-        
-
         public event EventHandler<AccelerationConditionChangeResult> Updated;
-
-        
-
-        
 
         /// <summary>
         ///     Create a new ADXL335 sensor object.
@@ -121,7 +110,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// <param name="xPin">Analog pin connected to the X axis output from the ADXL335 sensor.</param>
         /// <param name="yPin">Analog pin connected to the Y axis output from the ADXL335 sensor.</param>
         /// <param name="zPin">Analog pin connected to the Z axis output from the ADXL335 sensor.</param>
-        public Adxl335(IIODevice device, IPin xPin, IPin yPin, IPin zPin)
+        public Adxl335(IMeadowDevice device, IPin xPin, IPin yPin, IPin zPin)
         {
             _xPort = device.CreateAnalogInputPort(xPin);
             _yPort = device.CreateAnalogInputPort(yPin);
@@ -134,11 +123,7 @@ namespace Meadow.Foundation.Sensors.Motion
             ZVoltsPerG = 0.550f;
             SupplyVoltage = 3.3f;
         }
-
         
-
-        
-
         ///// <summary>
         ///// Convenience method to get the current temperature. For frequent reads, use
         ///// StartSampling() and StopSampling() in conjunction with the SampleBuffer.
@@ -235,7 +220,5 @@ namespace Meadow.Foundation.Sensors.Motion
         {
             return new Vector(await _xPort.Read(), await _yPort.Read(), await _zPort.Read());
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl337/Driver/Sensors.Motion.Adxl337/Adxl337.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl337/Driver/Sensors.Motion.Adxl337/Adxl337.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Foundation.Spatial;
+﻿using Meadow.Devices;
+using Meadow.Foundation.Spatial;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Motion;
 using System;
@@ -8,93 +9,83 @@ using System.Threading.Tasks;
 namespace Meadow.Foundation.Sensors.Motion
 {
     /// <summary>
-    ///     Driver for the ADXL337 triple axis accelerometer.
-    ///     +/- 5g
+    /// Driver for the ADXL337 triple axis accelerometer.
+    /// +/- 5g
     /// </summary>
     public class Adxl337 : FilterableChangeObservableBase<AccelerationConditionChangeResult, AccelerationConditions>,
         IAccelerometer
     {
-        
-
         /// <summary>
-        ///     Minimum value that can be used for the update interval when the
-        ///     sensor is being configured to generate interrupts.
+        /// Minimum value that can be used for the update interval when the
+        /// sensor is being configured to generate interrupts.
         /// </summary>
         public const ushort MinimumPollingPeriod = 100;
 
-        
-
-        
-
         /// <summary>
-        ///     Analog input channel connected to the x axis.
+        /// Analog input channel connected to the x axis.
         /// </summary>
         private readonly IAnalogInputPort _xPort;
 
         /// <summary>
-        ///     Analog input channel connected to the x axis.
+        /// Analog input channel connected to the x axis.
         /// </summary>
         private readonly IAnalogInputPort _yPort;
 
         /// <summary>
-        ///     Analog input channel connected to the x axis.
+        /// Analog input channel connected to the x axis.
         /// </summary>
         private readonly IAnalogInputPort _zPort;
 
         /// <summary>
-        ///     Voltage that represents 0g.  This is the supply voltage / 2.
+        /// Voltage that represents 0g.  This is the supply voltage / 2.
         /// </summary>
         private float _zeroGVoltage => SupplyVoltage / 2f;
 
-        
-
-        
-
         /// <summary>
-        ///     Acceleration along the X-axis.
+        /// Acceleration along the X-axis.
         /// </summary>
         /// <remarks>
-        ///     This property will only contain valid data after a call to Read or after
-        ///     an interrupt has been generated.
+        /// This property will only contain valid data after a call to Read or after
+        /// an interrupt has been generated.
         /// </remarks>
         public float XAcceleration => Conditions.XAcceleration.Value;
 
         /// <summary>
-        ///     Acceleration along the Y-axis.
+        /// Acceleration along the Y-axis.
         /// </summary>
         /// <remarks>
-        ///     This property will only contain valid data after a call to Read or after
-        ///     an interrupt has been generated.
+        /// This property will only contain valid data after a call to Read or after
+        /// an interrupt has been generated.
         /// </remarks>
         public float YAcceleration => Conditions.YAcceleration.Value;
 
         /// <summary>
-        ///     Acceleration along the Z-axis.
+        /// Acceleration along the Z-axis.
         /// </summary>
         /// <remarks>
-        ///     This property will only contain valid data after a call to Read or after
-        ///     an interrupt has been generated.
+        /// This property will only contain valid data after a call to Read or after
+        /// an interrupt has been generated.
         /// </remarks>
         public float ZAcceleration => Conditions.ZAcceleration.Value;
 
         /// <summary>
-        ///     Volts per G for the X axis.
+        /// Volts per G for the X axis.
         /// </summary>
         public float XVoltsPerG { get; set; }
 
         /// <summary>
-        ///     Volts per G for the X axis.
+        /// Volts per G for the X axis.
         /// </summary>
         public float YVoltsPerG { get; set; }
 
         /// <summary>
-        ///     Volts per G for the X axis.
+        /// Volts per G for the X axis.
         /// </summary>
         public float ZVoltsPerG { get; set; }
 
         /// <summary>
-        ///     Power supply voltage applied to the sensor.  This will be set (in the constructor)
-        ///     to 3.3V by default.
+        /// Power supply voltage applied to the sensor.  This will be set (in the constructor)
+        /// to 3.3V by default.
         /// </summary>
         public float SupplyVoltage { get; set; }
 
@@ -111,23 +102,15 @@ namespace Meadow.Foundation.Sensors.Motion
         /// <value><c>true</c> if sampling; otherwise, <c>false</c>.</value>
         public bool IsSampling { get; protected set; } = false;
 
-        
-
-        
-
         public event EventHandler<AccelerationConditionChangeResult> Updated;
 
-        
-
-        
-
         /// <summary>
-        ///     Create a new ADXL337 sensor object.
+        /// Create a new ADXL337 sensor object.
         /// </summary>
         /// <param name="xPin">Analog pin connected to the X axis output from the ADXL337 sensor.</param>
         /// <param name="yPin">Analog pin connected to the Y axis output from the ADXL337 sensor.</param>
         /// <param name="zPin">Analog pin connected to the Z axis output from the ADXL337 sensor.</param>
-		public Adxl337(IIODevice device, IPin xPin, IPin yPin, IPin zPin)
+        public Adxl337(IMeadowDevice device, IPin xPin, IPin yPin, IPin zPin)
         {
             _xPort = device.CreateAnalogInputPort(xPin);
             _yPort = device.CreateAnalogInputPort(yPin);
@@ -140,10 +123,6 @@ namespace Meadow.Foundation.Sensors.Motion
             ZVoltsPerG = 0.550f;
             SupplyVoltage = 3.3f;
         }
-
-        
-
-        
 
         ///// <summary>
         ///// Convenience method to get the current temperature. For frequent reads, use
@@ -224,7 +203,7 @@ namespace Meadow.Foundation.Sensors.Motion
         }
 
         /// <summary>
-        ///     Read the sensor output and convert the sensor readings into acceleration values.
+        /// Read the sensor output and convert the sensor readings into acceleration values.
         /// </summary>
         public async Task Update()
         {
@@ -234,14 +213,12 @@ namespace Meadow.Foundation.Sensors.Motion
         }
 
         /// <summary>
-        ///     Get the raw analog input values from the sensor.
+        /// Get the raw analog input values from the sensor.
         /// </summary>
         /// <returns>Vector object containing the raw sensor data from the analog pins.</returns>
         public async Task<Vector> GetRawSensorData()
         {
             return new Vector(await _xPort.Read(), await _yPort.Read(), await _zPort.Read());
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl337/Driver/Sensors.Motion.Adxl337/Adxl337.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl337/Driver/Sensors.Motion.Adxl337/Adxl337.cs
@@ -1,10 +1,9 @@
-﻿using Meadow.Devices;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Meadow.Foundation.Spatial;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Motion;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Motion
 {
@@ -110,7 +109,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// <param name="xPin">Analog pin connected to the X axis output from the ADXL337 sensor.</param>
         /// <param name="yPin">Analog pin connected to the Y axis output from the ADXL337 sensor.</param>
         /// <param name="zPin">Analog pin connected to the Z axis output from the ADXL337 sensor.</param>
-        public Adxl337(IMeadowDevice device, IPin xPin, IPin yPin, IPin zPin)
+        public Adxl337(IAnalogInputController device, IPin xPin, IPin yPin, IPin zPin)
         {
             _xPort = device.CreateAnalogInputPort(xPin);
             _yPort = device.CreateAnalogInputPort(yPin);

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl345/Driver/Sensors.Motion.ADXL345/Adxl345.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl345/Driver/Sensors.Motion.ADXL345/Adxl345.cs
@@ -14,15 +14,13 @@ namespace Meadow.Foundation.Sensors.Motion
     public class Adxl345 : FilterableChangeObservableBase<AccelerationConditionChangeResult, AccelerationConditions>,
         IAccelerometer
     {
+        public event EventHandler<AccelerationConditionChangeResult> Updated = delegate { };
+
         /// <summary>
         ///     Minimum value that can be used for the update interval when the
         ///     sensor is being configured to generate interrupts.
         /// </summary>
         public const ushort MinimumPollingPeriod = 100;
-
-        
-
-        
 
         /// <summary>
         ///     Communication bus used to communicate with the sensor.
@@ -32,10 +30,6 @@ namespace Meadow.Foundation.Sensors.Motion
         // internal thread lock
         private object lockObject = new object();
         private CancellationTokenSource SamplingTokenSource;
-
-        
-
-        
 
         /// <summary>
         ///     Possible values for the range (see DataFormat register).
@@ -64,10 +58,6 @@ namespace Meadow.Foundation.Sensors.Motion
             TwoHz = 0x02,
             OneHz = 0x03,
         }
-
-        
-
-        
 
         /// <summary>
         ///     Control registers for the ADXL345 chip.
@@ -108,10 +98,6 @@ namespace Meadow.Foundation.Sensors.Motion
             public static readonly byte Z0 = 0x36;
             public static readonly byte Z1 = 0x37;
         }
-
-        
-
-        
 
         /// <summary>
         ///     Acceleration along the X-axis.
@@ -182,16 +168,6 @@ namespace Meadow.Foundation.Sensors.Motion
             set { adxl345.WriteRegister(Registers.OffsetZ, (byte)value); }
         }
 
-        
-
-        
-
-        public event EventHandler<AccelerationConditionChangeResult> Updated;
-
-        
-
-        
-
         /// <summary>
         ///     Create a new instance of the ADXL345 communicating over the I2C interface.
         /// </summary>
@@ -207,10 +183,6 @@ namespace Meadow.Foundation.Sensors.Motion
                 throw new Exception("Invalid device ID.");
             }
         }
-
-        
-
-        
 
         ///// <summary>
         ///// Convenience method to get the current temperature. For frequent reads, use

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl362/Driver/Sensors.Motion.ADXL362/ADXL362.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl362/Driver/Sensors.Motion.ADXL362/ADXL362.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using Meadow.Devices;
 using Meadow.Foundation.Helpers;
-using Meadow.Foundation.Spatial;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Motion;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Motion
 {
@@ -29,7 +29,6 @@ namespace Meadow.Foundation.Sensors.Motion
         // internal thread lock
         private object _lock = new object();
         private CancellationTokenSource SamplingTokenSource;
-
 
         /// <summary>
         ///     Command byte (first byte in any communication).
@@ -747,7 +746,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// </summary>
         /// <param name="spiBus">Spi Bus object</param>
         /// <param name="chipSelect">Chip select pin.</param>
-        public Adxl362(IIODevice device, ISpiBus spiBus, IPin chipSelect)
+        public Adxl362(IMeadowDevice device, ISpiBus spiBus, IPin chipSelect)
         {
             //
             //  ADXL362 works in SPI mode 0 (CPOL = 0, CPHA = 0).
@@ -756,10 +755,6 @@ namespace Meadow.Foundation.Sensors.Motion
             Reset();
             Start();
         }
-
-        
-
-        
 
         ///// <summary>
         ///// Convenience method to get the current temperature. For frequent reads, use
@@ -994,7 +989,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// <param name="interruptPin1">Pin connected to interrupt pin 1 on the ADXL362.</param>
         /// <param name="interruptMap2">Bit mask for interrupt pin 2</param>
         /// <param name="interruptPin2">Pin connected to interrupt pin 2 on the ADXL362.</param>
-        private void ConfigureInterrupts(IIODevice device, byte interruptMap1, IPin interruptPin1, byte interruptMap2 = 0, IPin interruptPin2 = null) // TODO: interrupPin2 = IDigitalPin.GPIO_NONE
+        private void ConfigureInterrupts(IMeadowDevice device, byte interruptMap1, IPin interruptPin1, byte interruptMap2 = 0, IPin interruptPin2 = null) // TODO: interrupPin2 = IDigitalPin.GPIO_NONE
         {
             _adxl362.WriteBytes(new byte[] { Command.WriteRegister, interruptMap1, interruptMap2 });
 
@@ -1041,7 +1036,5 @@ namespace Meadow.Foundation.Sensors.Motion
             Array.Copy(registers, 2, dataRegisters, 0, amount);
             DebugInformation.DisplayRegisters(Registers.XAxis8Bits, dataRegisters);
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl362/Driver/Sensors.Motion.ADXL362/ADXL362.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl362/Driver/Sensors.Motion.ADXL362/ADXL362.cs
@@ -1,10 +1,10 @@
-﻿using Meadow.Devices;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Meadow.Devices;
 using Meadow.Foundation.Helpers;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Motion;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Motion
 {
@@ -746,7 +746,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// </summary>
         /// <param name="spiBus">Spi Bus object</param>
         /// <param name="chipSelect">Chip select pin.</param>
-        public Adxl362(IMeadowDevice device, ISpiBus spiBus, IPin chipSelect)
+        public Adxl362(IDigitalOutputController device, ISpiBus spiBus, IPin chipSelect)
         {
             //
             //  ADXL362 works in SPI mode 0 (CPOL = 0, CPHA = 0).

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl377/Driver/Sensors.Motion.Adxl377/Adxl377.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl377/Driver/Sensors.Motion.Adxl377/Adxl377.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Foundation.Spatial;
+﻿using Meadow.Devices;
+using Meadow.Foundation.Spatial;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Motion;
 using System;
@@ -39,10 +40,6 @@ namespace Meadow.Foundation.Sensors.Motion
         ///     Voltage that represents 0g.  This is the supply voltage / 2.
         /// </summary>
         private float _zeroGVoltage => SupplyVoltage / 2f;
-
-        
-
-        
 
         /// <summary>
         ///     Acceleration along the X-axis.
@@ -105,15 +102,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// <value><c>true</c> if sampling; otherwise, <c>false</c>.</value>
         public bool IsSampling { get; protected set; } = false;
 
-        
-
-        
-
         public event EventHandler<AccelerationConditionChangeResult> Updated;
-
-        
-
-        
 
         /// <summary>
         ///     Create a new ADXL337 sensor object.
@@ -121,7 +110,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// <param name="xPin">Analog pin connected to the X axis output from the ADXL335 sensor.</param>
         /// <param name="yPin">Analog pin connected to the Y axis output from the ADXL335 sensor.</param>
         /// <param name="zPin">Analog pin connected to the Z axis output from the ADXL335 sensor.</param>
-        public Adxl377(IIODevice device, IPin xPin, IPin yPin, IPin zPin)
+        public Adxl377(IMeadowDevice device, IPin xPin, IPin yPin, IPin zPin)
         {
             _xPort = device.CreateAnalogInputPort(xPin);
             _yPort = device.CreateAnalogInputPort(yPin);
@@ -134,10 +123,6 @@ namespace Meadow.Foundation.Sensors.Motion
             ZVoltsPerG = 0.00825f;
             SupplyVoltage = 3.3f;
         }
-
-        
-
-        
 
         ///// <summary>
         ///// Convenience method to get the current temperature. For frequent reads, use
@@ -235,7 +220,5 @@ namespace Meadow.Foundation.Sensors.Motion
         {
             return new Vector(await _xPort.Read(), await _yPort.Read(), await _zPort.Read());
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl377/Driver/Sensors.Motion.Adxl377/Adxl377.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Adxl377/Driver/Sensors.Motion.Adxl377/Adxl377.cs
@@ -1,10 +1,9 @@
-﻿using Meadow.Devices;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Meadow.Foundation.Spatial;
 using Meadow.Hardware;
 using Meadow.Peripherals.Sensors.Motion;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Meadow.Foundation.Sensors.Motion
 {
@@ -110,7 +109,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// <param name="xPin">Analog pin connected to the X axis output from the ADXL335 sensor.</param>
         /// <param name="yPin">Analog pin connected to the Y axis output from the ADXL335 sensor.</param>
         /// <param name="zPin">Analog pin connected to the Z axis output from the ADXL335 sensor.</param>
-        public Adxl377(IMeadowDevice device, IPin xPin, IPin yPin, IPin zPin)
+        public Adxl377(IAnalogInputController device, IPin xPin, IPin yPin, IPin zPin)
         {
             _xPort = device.CreateAnalogInputPort(xPin);
             _yPort = device.CreateAnalogInputPort(yPin);

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Apds9960/Driver/Sensors.Motion.APDS9960/Apds9960.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Apds9960/Driver/Sensors.Motion.APDS9960/Apds9960.cs
@@ -1,16 +1,15 @@
-﻿
-
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 using System.Threading;
-using Meadow.Hardware;
 
 namespace Meadow.Foundation.Sensors.Motion
 {
     public class Apds9960
     {
         /// <summary>
-        ///     Communication bus used to communicate with the sensor.
-        ///     This driver is a work-in-progress, contributions are always welcome
+        /// Communication bus used to communicate with the sensor.
+        /// This driver is a work-in-progress, contributions are always welcome
         /// </summary>
         private readonly II2cPeripheral apds9960;
 
@@ -188,10 +187,6 @@ namespace Meadow.Foundation.Sensors.Motion
         static readonly byte DEFAULT_GCONF3 = 0;       // All photodiodes active during gesture
         static readonly byte DEFAULT_GIEN = 0;       // Disable gesture interrupts
 
-        
-
-        
-
         /* Direction definitions */
         public enum Direction
         {
@@ -214,16 +209,12 @@ namespace Meadow.Foundation.Sensors.Motion
             ALL_STATE
         };
 
-        
-
-        
-
         /// <summary>
-        ///     Create a new instance of the APDS9960 communicating over the I2C interface.
+        /// Create a new instance of the APDS9960 communicating over the I2C interface.
         /// </summary>
         /// <param name="address">Address of the I2C sensor</param>
         /// <param name="i2cBus">SI2C bus object</param>
-        public Apds9960(IIODevice device, II2cBus i2cBus, IPin interruptPin, byte address = 0x39)
+        public Apds9960(IMeadowDevice device, II2cBus i2cBus, IPin interruptPin, byte address = 0x39)
         {
             apds9960 = new I2cPeripheral(i2cBus, address);
 
@@ -249,17 +240,12 @@ namespace Meadow.Foundation.Sensors.Motion
             gestureDirection = (int)Direction.NONE;
 
             Initialize();
-
         }
 
         private void InterruptPort_Changed(object sender, DigitalInputPortEventArgs e)
         {
         //    throw new NotImplementedException();
         }
-
-        
-
-        
 
         void Initialize()
         {
@@ -1674,10 +1660,6 @@ namespace Meadow.Foundation.Sensors.Motion
             apds9960.WriteRegister(APDS9960_GCONF4, val);
         }
 
-        
-
-        
-
         /* Container for gesture data */
         public class GestureData
         {
@@ -1690,8 +1672,5 @@ namespace Meadow.Foundation.Sensors.Motion
             public byte InThreshold { get; set; }
             public byte OutThreshold { get; set; }
         }
-
-        
     }
-
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Hcsens0040/Driver/Sensors.Motion.Hcsens0040/HCSENS0040.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Hcsens0040/Driver/Sensors.Motion.Hcsens0040/HCSENS0040.cs
@@ -1,38 +1,35 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 
 namespace Meadow.Foundation.Sensors.Motion
 {
     /// <summary>
-    ///     Create a new Hscens0040 object.
+    /// Create a new Hscens0040 object.
     /// </summary>
     public class Hcsens0040
     {
         /// <summary>
-        ///     Digital input port
+        /// Digital input port
         /// </summary>
         private readonly IDigitalInputPort _digitalInputPort;
 
         /// <summary>
-        ///     Delgate for the motion start and end events.
+        /// Delgate for the motion start and end events.
         /// </summary>
         public delegate void MotionChange(object sender);
 
         /// <summary>
-        ///     Event raised when motion is detected.
+        /// Event raised when motion is detected.
         /// </summary>
         public event MotionChange OnMotionDetected;
-
-        
-
-        
 
         /// <summary>
         /// Create a new Parallax PIR object connected to an input pin and IO Device.
         /// </summary>
         /// <param name="device"></param>
         /// <param name="inputPin"></param>        
-        public Hcsens0040(IIODevice device, IPin pin) : 
+        public Hcsens0040(IMeadowDevice device, IPin pin) : 
             this (device.CreateDigitalInputPort(pin, InterruptMode.EdgeRising, ResistorMode.InternalPullDown)) { }
 
         /// <summary>
@@ -52,12 +49,8 @@ namespace Meadow.Foundation.Sensors.Motion
             }
         }
 
-        
-
-        
-
         /// <summary>
-        ///     Catch the PIR motion change interrupts and work out which interrupt should be raised.
+        /// Catch the PIR motion change interrupts and work out which interrupt should be raised.
         /// </summary>
         private void DigitalInputPortChanged(object sender, DigitalInputPortEventArgs e)
         {
@@ -66,7 +59,5 @@ namespace Meadow.Foundation.Sensors.Motion
                 OnMotionDetected?.Invoke(this);
             }
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Hcsens0040/Driver/Sensors.Motion.Hcsens0040/HCSENS0040.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Hcsens0040/Driver/Sensors.Motion.Hcsens0040/HCSENS0040.cs
@@ -1,6 +1,5 @@
-﻿using Meadow.Devices;
+﻿using System;
 using Meadow.Hardware;
-using System;
 
 namespace Meadow.Foundation.Sensors.Motion
 {
@@ -29,7 +28,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// </summary>
         /// <param name="device"></param>
         /// <param name="inputPin"></param>        
-        public Hcsens0040(IMeadowDevice device, IPin pin) : 
+        public Hcsens0040(IDigitalInputController device, IPin pin) : 
             this (device.CreateDigitalInputPort(pin, InterruptMode.EdgeRising, ResistorMode.InternalPullDown)) { }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Mag3110/Driver/Sensors.Motion.MAG3110/MAG3110.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.Mag3110/Driver/Sensors.Motion.MAG3110/MAG3110.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 
 namespace Meadow.Foundation.Sensors.Motion
@@ -6,7 +7,7 @@ namespace Meadow.Foundation.Sensors.Motion
     public class Mag3110
     {
         /// <summary>
-        ///     Sensor readings to be passed back when an interrupt is generated.
+        /// Sensor readings to be passed back when an interrupt is generated.
         /// </summary>
         public struct SensorReading
         {
@@ -16,7 +17,7 @@ namespace Meadow.Foundation.Sensors.Motion
         }
 
         /// <summary>
-        ///     Register addresses in the sensor.
+        /// Register addresses in the sensor.
         /// </summary>
         private static class Registers
         {
@@ -41,52 +42,52 @@ namespace Meadow.Foundation.Sensors.Motion
         }
 
         /// <summary>
-        ///     Delegate for the OnDataReceived event.
+        /// Delegate for the OnDataReceived event.
         /// </summary>
         /// <param name="sensorReading">Sensor readings from the MAG3110.</param>
         public delegate void ReadingComplete(SensorReading sensorReading);
 
         /// <summary>
-        ///     Generated when the sensor indicates that data is ready for processing.
+        /// Generated when the sensor indicates that data is ready for processing.
         /// </summary>
         public event ReadingComplete OnReadingComplete;
 
         /// <summary>
-        ///     MAG3110 object.
+        /// MAG3110 object.
         /// </summary>
         private readonly II2cPeripheral i2cPeripheral;
 
         /// <summary>
-        ///     Interrupt port used to detect then end of a conversion.
+        /// Interrupt port used to detect then end of a conversion.
         /// </summary>
         private readonly IDigitalInputPort interruptPort;
 
         /// <summary>
-        ///     Reading from the X axis.
+        /// Reading from the X axis.
         /// </summary>
         /// <remarks>
-        ///     Data in this property is only current after a call to Read.
+        /// Data in this property is only current after a call to Read.
         /// </remarks>
         public short X { get; private set; }
 
         /// <summary>
-        ///     Reading from the Y axis.
+        /// Reading from the Y axis.
         /// </summary>
         /// <remarks>
-        ///     Data in this property is only current after a call to Read.
+        /// Data in this property is only current after a call to Read.
         /// </remarks>
         public short Y { get; private set; }
 
         /// <summary>
-        ///     Reading from the Z axis.
+        /// Reading from the Z axis.
         /// </summary>
         /// <remarks>
-        ///     Data in this property is only current after a call to Read.
+        /// Data in this property is only current after a call to Read.
         /// </remarks>
         public short Z { get; private set; }
 
         /// <summary>
-        ///     Temperature of the sensor die.
+        /// Temperature of the sensor die.
         /// </summary>
         public sbyte Temperature
         {
@@ -94,7 +95,7 @@ namespace Meadow.Foundation.Sensors.Motion
         }
 
         /// <summary>
-        ///     Change or get the standby status of the sensor.
+        /// Change or get the standby status of the sensor.
         /// </summary>
         public bool Standby
         {
@@ -119,10 +120,10 @@ namespace Meadow.Foundation.Sensors.Motion
         }
 
         /// <summary>
-        ///     Indicate if there is any data ready for reading (x, y or z).
+        /// Indicate if there is any data ready for reading (x, y or z).
         /// </summary>
         /// <remarks>
-        ///     See section 5.1.1 of the datasheet.
+        /// See section 5.1.1 of the datasheet.
         /// </remarks>
         public bool DataReady
         {
@@ -130,12 +131,12 @@ namespace Meadow.Foundation.Sensors.Motion
         }
 
         /// <summary>
-        ///     Enable or disable interrupts.
+        /// Enable or disable interrupts.
         /// </summary>
         /// <remarks>
-        ///     Interrupts can be triggered when a conversion completes (see section 4.2.5
-        ///     of the datasheet).  The interrupts are tied to the ZYXDR bit in the DR Status
-        ///     register.
+        /// Interrupts can be triggered when a conversion completes (see section 4.2.5
+        /// of the datasheet).  The interrupts are tied to the ZYXDR bit in the DR Status
+        /// register.
         /// </remarks>
         private bool _digitalInputsEnabled;
 
@@ -166,7 +167,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// <param name="interruptPin">Interrupt pin used to detect end of conversions.</param>
         /// <param name="address">Address of the MAG3110 (default = 0x0e).</param>
         /// <param name="speed">Speed of the I2C bus (default = 400 KHz).</param>        
-        public Mag3110(IIODevice device, II2cBus i2cBus, IPin interruptPin = null, byte address = 0x0e, ushort speed = 400) :
+        public Mag3110(IMeadowDevice device, II2cBus i2cBus, IPin interruptPin = null, byte address = 0x0e, ushort speed = 400) :
             this (i2cBus, device.CreateDigitalInputPort(interruptPin, InterruptMode.EdgeRising, ResistorMode.Disabled), address) { }
 
         /// <summary>
@@ -194,7 +195,7 @@ namespace Meadow.Foundation.Sensors.Motion
         }
 
         /// <summary>
-        ///     Reset the sensor.
+        /// Reset the sensor.
         /// </summary>
         public void Reset()
         {
@@ -205,7 +206,7 @@ namespace Meadow.Foundation.Sensors.Motion
         }
 
         /// <summary>
-        ///     Force the sensor to make a reading and update the relevanyt properties.
+        /// Force the sensor to make a reading and update the relevanyt properties.
         /// </summary>
         public void Read()
         {
@@ -219,7 +220,7 @@ namespace Meadow.Foundation.Sensors.Motion
         }
 
         /// <summary>
-        ///     Interrupt from the MAG3110 conversion complete interrupt.
+        /// Interrupt from the MAG3110 conversion complete interrupt.
         /// </summary>
         private void DigitalInputPortChanged(object sender, DigitalInputPortEventArgs e)
         {

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.ParallaxPir/Driver/Sensors.Motion.ParallaxPir/ParallaxPir.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.ParallaxPir/Driver/Sensors.Motion.ParallaxPir/ParallaxPir.cs
@@ -1,7 +1,5 @@
-﻿using Meadow.Devices;
+﻿using System;
 using Meadow.Hardware;
-using System;
-using static Meadow.Hardware.DigitalPortBase;
 
 namespace Meadow.Foundation.Sensors.Motion
 {
@@ -35,7 +33,7 @@ namespace Meadow.Foundation.Sensors.Motion
         /// </summary>
         /// <param name="device"></param>
         /// <param name="inputPin"></param>
-        public ParallaxPir(IMeadowDevice device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) : 
+        public ParallaxPir(IDigitalInputController device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) : 
             this (device.CreateDigitalInputPort(pin, interruptMode, resistorMode, debounceDuration, glitchFilterCycleCount)) { }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Motion.ParallaxPir/Driver/Sensors.Motion.ParallaxPir/ParallaxPir.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Motion.ParallaxPir/Driver/Sensors.Motion.ParallaxPir/ParallaxPir.cs
@@ -1,50 +1,41 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 using static Meadow.Hardware.DigitalPortBase;
 
 namespace Meadow.Foundation.Sensors.Motion
 {
     /// <summary>
-    ///     Create a new Parallax PIR object.
+    /// Create a new Parallax PIR object.
     /// </summary>
     public class ParallaxPir
     {
-        
-
         /// <summary>
-        ///     Digital input port
+        /// Digital input port
         /// </summary>
         private readonly IDigitalInputPort _digitalInputPort;
 
-        
-
-        
-
         /// <summary>
-        ///     Delgate for the motion start and end events.
+        /// Delgate for the motion start and end events.
         /// </summary>
         public delegate void MotionChange(object sender);
 
         /// <summary>
-        ///     Event raised when motion is detected.
+        /// Event raised when motion is detected.
         /// </summary>
         public event MotionChange OnMotionStart;
 
         /// <summary>
-        ///     Event raised when the PIR indicates that there is not longer any motion.
+        /// Event raised when the PIR indicates that there is not longer any motion.
         /// </summary>
         public event MotionChange OnMotionEnd;
-
-        
-
-        
 
         /// <summary>
         /// Create a new Parallax PIR object connected to an input pin and IO Device.
         /// </summary>
         /// <param name="device"></param>
-        /// <param name="inputPin"></param>        
-        public ParallaxPir(IIODevice device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) : 
+        /// <param name="inputPin"></param>
+        public ParallaxPir(IMeadowDevice device, IPin pin, InterruptMode interruptMode, ResistorMode resistorMode, int debounceDuration = 20, int glitchFilterCycleCount = 0) : 
             this (device.CreateDigitalInputPort(pin, interruptMode, resistorMode, debounceDuration, glitchFilterCycleCount)) { }
 
         /// <summary>
@@ -65,12 +56,8 @@ namespace Meadow.Foundation.Sensors.Motion
             }
         }
 
-        
-
-        
-
         /// <summary>
-        ///     Catch the PIR motion change interrupts and work out which interrupt should be raised.
+        /// Catch the PIR motion change interrupts and work out which interrupt should be raised.
         /// </summary>
         private void DigitalInputPortChanged(object sender, DigitalInputPortEventArgs e)
         {
@@ -83,7 +70,5 @@ namespace Meadow.Foundation.Sensors.Motion
                 OnMotionEnd?.Invoke(this);
             }
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Radio.Rfid.IDxxLA/Driver/Sensors.Radio.Rfid.IDxxLA/IDxxLA.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Radio.Rfid.IDxxLA/Driver/Sensors.Radio.Rfid.IDxxLA/IDxxLA.cs
@@ -1,9 +1,8 @@
-﻿using Meadow.Devices;
-using Meadow.Hardware;
-using Meadow.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Meadow.Hardware;
+using Meadow.Utilities;
 
 namespace Meadow.Foundation.Sensors.Radio.Rfid
 {
@@ -35,7 +34,7 @@ namespace Meadow.Foundation.Sensors.Radio.Rfid
         /// </summary>
         /// <param name="device">Device to use</param>
         /// <param name="serialPortName">Port name to use</param>
-        public IDxxLA(IMeadowDevice device, SerialPortName serialPortName) :
+        public IDxxLA(ISerialMessageController device, SerialPortName serialPortName) :
             this(device.CreateSerialMessagePort(
                     serialPortName,
                     suffixDelimiter: new byte[] { EndToken },

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Radio.Rfid.IDxxLA/Driver/Sensors.Radio.Rfid.IDxxLA/IDxxLA.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Radio.Rfid.IDxxLA/Driver/Sensors.Radio.Rfid.IDxxLA/IDxxLA.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using Meadow.Foundation.Sensors.Radio.Rfid.Serial.Helpers;
-using Meadow.Foundation.Helpers;
+﻿using Meadow.Devices;
 using Meadow.Hardware;
 using Meadow.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Meadow.Foundation.Sensors.Radio.Rfid
 {
@@ -36,7 +35,7 @@ namespace Meadow.Foundation.Sensors.Radio.Rfid
         /// </summary>
         /// <param name="device">Device to use</param>
         /// <param name="serialPortName">Port name to use</param>
-        public IDxxLA(IIODevice device, SerialPortName serialPortName) :
+        public IDxxLA(IMeadowDevice device, SerialPortName serialPortName) :
             this(device.CreateSerialMessagePort(
                     serialPortName,
                     suffixDelimiter: new byte[] { EndToken },

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Sound.Ky038/Driver/Sensors.Sound.Ky038/Ky038.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Sound.Ky038/Driver/Sensors.Sound.Ky038/Ky038.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 using System.Threading;
 
@@ -10,7 +11,7 @@ namespace Meadow.Foundation.Sensors.Sound
         protected IAnalogInputPort analogPort;
         protected IDigitalInputPort digitalInputPort;
 
-        public Ky038(IIODevice device, IPin A0, IPin D0) : 
+        public Ky038(IMeadowDevice device, IPin A0, IPin D0) : 
             this (device.CreateAnalogInputPort(A0), device.CreateDigitalInputPort(D0))
         {
         }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Temperature.Lm75/Driver/Sensors.Temperature.Lm75/Lm75.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Temperature.Lm75/Driver/Sensors.Temperature.Lm75/Lm75.cs
@@ -30,7 +30,6 @@ namespace Meadow.Foundation.Sensors.Temperature
         /// </summary>
         private readonly II2cPeripheral lm75;
 
-
         public byte DEFAULT_ADDRESS => 0x48;
 
         /// <summary>
@@ -54,15 +53,7 @@ namespace Meadow.Foundation.Sensors.Temperature
         /// <value><c>true</c> if sampling; otherwise, <c>false</c>.</value>
         public bool IsSampling { get; protected set; } = false;
 
-        
-
-        
-
         public event EventHandler<AtmosphericConditionChangeResult> Updated;
-
-        
-
-        
 
         /// <summary>
         ///     Create a new TMP102 object using the default configuration for the sensor.
@@ -72,10 +63,6 @@ namespace Meadow.Foundation.Sensors.Temperature
         {
             lm75 = new I2cPeripheral(i2cBus, address);
         }
-
-        
-
-        
 
         /// <summary>
         /// Convenience method to get the current sensor readings. For frequent reads, use
@@ -174,7 +161,5 @@ namespace Meadow.Foundation.Sensors.Temperature
             //only accurate to +/- 0.1 degrees
             Conditions.Temperature = (float)Math.Round(temp, 1);
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Temperature.Tmp102/Driver/Sensors.Temperature.Tmp102/Tmp102.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Temperature.Tmp102/Driver/Sensors.Temperature.Tmp102/Tmp102.cs
@@ -78,15 +78,7 @@ namespace Meadow.Foundation.Sensors.Temperature
         /// <value><c>true</c> if sampling; otherwise, <c>false</c>.</value>
         public bool IsSampling { get; protected set; } = false;
 
-        
-
-        
-
         public event EventHandler<AtmosphericConditionChangeResult> Updated;
-
-        
-
-        
 
         /// <summary>
         ///     Create a new TMP102 object using the default configuration for the sensor.
@@ -101,10 +93,6 @@ namespace Meadow.Foundation.Sensors.Temperature
             _sensorResolution = (configuration[1] & 0x10) > 0 ?
                                  Resolution.Resolution13Bits : Resolution.Resolution12Bits;
         }
-
-        
-
-        
 
         /// <summary>
         /// Convenience method to get the current sensor readings. For frequent reads, use
@@ -193,7 +181,5 @@ namespace Meadow.Foundation.Sensors.Temperature
             }
             Conditions.Temperature = (float)(sensorReading * 0.0625);
         }
-
-        
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Weather.WindVane/Driver/Sensors.Weather.WindVane/WindVane.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Weather.WindVane/Driver/Sensors.Weather.WindVane/WindVane.cs
@@ -1,9 +1,8 @@
-﻿using Meadow.Devices;
-using Meadow.Hardware;
-using Meadow.Units;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Meadow.Hardware;
+using Meadow.Units;
 using static Meadow.Foundation.Sensors.Weather.WindVane;
 
 namespace Meadow.Foundation.Sensors.Weather
@@ -45,7 +44,7 @@ namespace Meadow.Foundation.Sensors.Weather
         /// <param name="device">The IO Device.</param>
         /// <param name="analogInputPin">The analog input pin.</param>
         /// <param name="azimuthVoltages">Optional. Supply if you have custom azimuth voltages.</param>
-        public WindVane(IMeadowDevice device, IPin analogInputPin, IDictionary<float, Azimuth> azimuthVoltages = null)
+        public WindVane(IAnalogInputController device, IPin analogInputPin, IDictionary<float, Azimuth> azimuthVoltages = null)
             : this(device.CreateAnalogInputPort(analogInputPin), azimuthVoltages)
         {
         }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Weather.WindVane/Driver/Sensors.Weather.WindVane/WindVane.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Weather.WindVane/Driver/Sensors.Weather.WindVane/WindVane.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using Meadow;
+﻿using Meadow.Devices;
 using Meadow.Hardware;
-using Meadow.Foundation.Sensors;
 using Meadow.Units;
-using static Meadow.Foundation.Sensors.Weather.WindVane;
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using static Meadow.Foundation.Sensors.Weather.WindVane;
 
 namespace Meadow.Foundation.Sensors.Weather
 {
@@ -46,7 +45,7 @@ namespace Meadow.Foundation.Sensors.Weather
         /// <param name="device">The IO Device.</param>
         /// <param name="analogInputPin">The analog input pin.</param>
         /// <param name="azimuthVoltages">Optional. Supply if you have custom azimuth voltages.</param>
-        public WindVane(IIODevice device, IPin analogInputPin, IDictionary<float, Azimuth> azimuthVoltages = null)
+        public WindVane(IMeadowDevice device, IPin analogInputPin, IDictionary<float, Azimuth> azimuthVoltages = null)
             : this(device.CreateAnalogInputPort(analogInputPin), azimuthVoltages)
         {
         }

--- a/Source/Meadow.Foundation.Peripherals/Servos.ServoCore/Driver/Servos.ServoCore/ServoCore.cs
+++ b/Source/Meadow.Foundation.Peripherals/Servos.ServoCore/Driver/Servos.ServoCore/ServoCore.cs
@@ -1,10 +1,11 @@
+using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Servos
 {
     public class Servo : ServoBase
     {
-        public Servo(IIODevice device, IPin pwm, ServoConfig config) :
+        public Servo(IMeadowDevice device, IPin pwm, ServoConfig config) :
             this(device.CreatePwmPort(pwm), config) { }
 
         public Servo(IPwmPort pwm, ServoConfig config) : 

--- a/Source/Meadow.Foundation.Peripherals/Servos.ServoCore/Driver/Servos.ServoCore/ServoCore.cs
+++ b/Source/Meadow.Foundation.Peripherals/Servos.ServoCore/Driver/Servos.ServoCore/ServoCore.cs
@@ -1,11 +1,10 @@
-using Meadow.Devices;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Servos
 {
     public class Servo : ServoBase
     {
-        public Servo(IMeadowDevice device, IPin pwm, ServoConfig config) :
+        public Servo(IPwmOutputController device, IPin pwm, ServoConfig config) :
             this(device.CreatePwmPort(pwm), config) { }
 
         public Servo(IPwmPort pwm, ServoConfig config) : 

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.Nrf24l01/Driver/Transceivers.Nrf24l01/Nrf24l01.cs
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.Nrf24l01/Driver/Transceivers.Nrf24l01/Nrf24l01.cs
@@ -1,7 +1,7 @@
-﻿using Meadow.Hardware;
+﻿using Meadow.Devices;
+using Meadow.Hardware;
 using System;
 using System.Linq;
-using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 
@@ -173,7 +173,7 @@ namespace Meadow.Foundation.Transceivers
         byte[] pipe0_reading_address = new byte[5];
 
         public Nrf24l01(
-            IIODevice device, 
+            IMeadowDevice device, 
             ISpiBus spiBus, 
             IPin chipEnablePin, 
             IPin chipSelectLine, 


### PR DESCRIPTION
Updated all drivers that had IIODevice in their constructor and those drivers that inherited from IIODevice to the appropriate device type. Also cleaned up the code removing extra space lines, fix comments indentation, redundant **this.** instructions.