### PR TITLE
[TextDisplayMenu] Allow sub-menu of 1 item

### DIFF
--- a/Source/Meadow.Foundation.Libraries_and_Frameworks/Displays.TextDisplayMenu/Driver/BaseClasses/MenuItemBase.cs
+++ b/Source/Meadow.Foundation.Libraries_and_Frameworks/Displays.TextDisplayMenu/Driver/BaseClasses/MenuItemBase.cs
@@ -23,7 +23,7 @@ namespace Meadow.Foundation.Displays.TextDisplayMenu
         [JsonProperty("value")]
         public object Value { get; set; }
 
-        public bool HasSubItems => SubItems != null && SubItems.Length > 1;
+        public bool HasSubItems => SubItems != null && SubItems.Length > 0;
 
         public bool IsEditable => Value != null;
 


### PR DESCRIPTION
{Fixes #381}

I'm not sure if this has other implications around sub-menus, but it does fix the issue I was seeing with single-item sub-menu pages.