### PR TITLE
[TextDisplayMenu] Cannot have sub-menu of 1 item

### DIFF
--- a/Source/Meadow.Foundation.Libraries_and_Frameworks/Displays.TextDisplayMenu/Driver/BaseClasses/MenuItemBase.cs
+++ b/Source/Meadow.Foundation.Libraries_and_Frameworks/Displays.TextDisplayMenu/Driver/BaseClasses/MenuItemBase.cs
@@ -23,7 +23,7 @@ namespace Meadow.Foundation.Displays.TextDisplayMenu
         [JsonProperty("value")]
         public object Value { get; set; }
 
-        public bool HasSubItems => SubItems != null && SubItems.Length > 1;
+        public bool HasSubItems => SubItems != null && SubItems.Length > 0;
 
         public bool IsEditable => Value != null;
 


### PR DESCRIPTION
If you have a menu with a single sub-item, it will not be recognized as a sub-menu. Selecting the resulting menu item it will neither trigger `Selected` nor open a sub-menu.

```csharp
var menuItems = new MenuItem[]
{
    ...
    new MenuItem("Options", subItems: new MenuItem[]
    {
        new MenuItem($"Version {version}"),
    }),
};
```
