### PR TITLE
Add initial issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Meadow.Foundation (please complete the following information as best as you can):**
+ - NuGet package version: [e.g., v0.34.1]
+
+**Developer tools (please complete the following information as best as you can):**
+ - OS and version: [e.g., Windows 10 v22H2, macOS Monterey v12.6]
+ - IDE and version: [e.g., Visual Studio Professional 2022 v17.3.5, Visual Studio 2022 for Mac v17.3.5]
+ - Meadow extension for IDE version: [e.g., VS 2022 Tools for Meadow v0.19.9]
+
+**Meadow (please complete the following information as best as you can):**
+Most of these vaues can be found by running `meadow device info` using the [Meadow CLI](http://developer.wildernesslabs.co/Meadow/Meadow_Basics/Meadow_CLI/).
+ - Meadow hardware version: [e.g. F7v2, CCMv2]
+ - Meadow OS version: [e.g., v0.6.7.19]
+ - If they are different, please provide these versions as well.
+   - Meadow Mono version: [e.g., v0.6.7.19]
+   - Meadow coprocessor version: [e.g., v0.6.7.19]
+
+**Additional context**
+Add any other context about the problem here. If you are working with additional external hardware/sensors, please list them here.


### PR DESCRIPTION
Initial bug report and feature request templates to make sure we are getting as much useful information as possible. I customized the samples as best as I could for Meadow in the [template proposal on Meadow_Issues](https://github.com/WildernessLabs/Meadow_Issues/pull/233) to help track down version or hardware-specific issues. Then, for this one, I just added a **Meadow.Foundation** section.

If there are other things from the user that could help, let me know (or add them directly).