### PR TITLE
Fix XML error to show remarks in Intellisense tip

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Sensors.Temperature.Thermistor/Driver/Thermistor.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Temperature.Thermistor/Driver/Thermistor.cs
@@ -1,4 +1,4 @@
-﻿using Meadow.Hardware;
+using Meadow.Hardware;
 using Meadow.Peripherals.Sensors;
 using Meadow.Units;
 using System;
@@ -11,11 +11,9 @@ namespace Meadow.Foundation.Sensors.Temperature
     /// <remarks>
     /// Typical wiring
     /// 
-    /// <![CDATA[
-    /// 3.3V >-----[ 10k R ]---+-------------< Analog_in
+    /// 3.3V >-----[ 10k R ]---+-------------&lt; Analog_in
     ///                        |
-    ///                        +---[ TM ]--- < GND
-    /// ]]>
+    ///                        +---[ TM ]--- &lt; GND
     /// </remarks>
     public abstract class Thermistor : SamplingSensorBase<Units.Temperature>, ITemperatureSensor
     {

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Temperature.Thermistor/Driver/Thermistor.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Temperature.Thermistor/Driver/Thermistor.cs
@@ -11,9 +11,11 @@ namespace Meadow.Foundation.Sensors.Temperature
     /// <remarks>
     /// Typical wiring
     /// 
+    /// <![CDATA[
     /// 3.3V >-----[ 10k R ]---+-------------< Analog_in
     ///                        |
     ///                        +---[ TM ]--- < GND
+    /// ]]>
     /// </remarks>
     public abstract class Thermistor : SamplingSensorBase<Units.Temperature>, ITemperatureSensor
     {


### PR DESCRIPTION
While still not ideal yet, since line breaks are not preserved, this at least gets the remark XML to show up.

Also, it fixes an XML build warning.

Before:
![image](https://user-images.githubusercontent.com/713665/200420381-bdfab976-0e5b-4f54-913a-95127f2f26f3.png)

After:
![image](https://user-images.githubusercontent.com/713665/200421337-e8331aac-60f4-4279-9243-3a24fcbd5206.png)

## Other failed attempts

So many attempts to get this to render correctly have failed. They either don't add line breaks or don't add the leading whitespace. For example, this simple version _should_ do both but doesn't. (And adding a `CDATA` to each individual line also doesn't work.)

```csharp
/// <![CDATA[
/// 3.3V >-----[ 10k R ]---+-------------< Analog_in
///                        |
///                        +---[ TM ]--- < GND
/// ]]>
```