### PR TITLE
Add `Color.Equals()` override without casting.

### DIFF
--- a/Source/Meadow.Foundation.Core/Color.cs
+++ b/Source/Meadow.Foundation.Core/Color.cs
@@ -292,6 +292,16 @@ namespace Meadow.Foundation
             return base.Equals(obj);
         }
 
+        /// <summary>
+        /// Compare two color structs for equality
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns>true if equals</returns>
+        public readonly bool Equals(Color other)
+        {
+            return EqualsInner(this, other);
+        }
+
         static bool EqualsInner(Color color1, Color color2)
         {
              return color1.R == color2.R && color1.G == color2.G && color1.B == color2.B && color1.A == color2.A;


### PR DESCRIPTION
Currently, if someone wants to check for color equality they may do `color1.Equals(color2)`. This currently ends up calling the `Equals(object other)` which requires type checks and casting.  This adds significant performance penalty, which adds up in some contexts (e.g. checking each pixel you are drawing isn't the designated transparent color).

This can be worked around by using the `==` and `!=` overloads, but it's not obvious without looking at the source code that these are overloaded to be better optimized. Therefore, to help with the pit of success I've added an Equals overload that doesn't require casting, and significantly improves performance when called many times.