### PR TITLE
Add launch.config to sample projects for VSCode users

### DIFF
--- a/Source/Meadow.Foundation.Core.Samples/Audio.PiezoSpeaker_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Audio.PiezoSpeaker_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Generators.SoftPwmPort_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Generators.SoftPwmPort_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Leds.LedBarGraph_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Leds.LedBarGraph_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Leds.Led_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Leds.Led_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Leds.PwmLedBarGraph_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Leds.PwmLedBarGraph_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Leds.PwmLed_Onboard_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Leds.PwmLed_Onboard_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Leds.PwmLed_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Leds.PwmLed_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Leds.RgbLed_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Leds.RgbLed_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Leds.RgbPwmLed_Onboard_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Leds.RgbPwmLed_Onboard_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Leds.RgbPwmLed_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Leds.RgbPwmLed_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Motor.HBridgeMotor_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Motor.HBridgeMotor_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Relays.Relay_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Relays.Relay_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.Buttons.PushButton_BasicSample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.Buttons.PushButton_BasicSample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.Buttons.PushButton_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.Buttons.PushButton_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.Environmental.AnalogWaterLevel_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.Environmental.AnalogWaterLevel_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.HID.AnalogJoystick_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.HID.AnalogJoystick_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.HallEffect_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.HallEffect_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.Light.AnalogLightSensor_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.Light.AnalogLightSensor_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.Rotary.RotaryEncoderWithButton_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.Rotary.RotaryEncoderWithButton_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.Rotary.RotaryEncoder_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.Rotary.RotaryEncoder_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.Switches.DipSwitch_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.Switches.DipSwitch_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.Switches.SpdtSwitch_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.Switches.SpdtSwitch_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.Switches.SpstSwitch_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.Switches.SpstSwitch_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}

--- a/Source/Meadow.Foundation.Core.Samples/Sensors.Temperature.AnalogTemperature_Sample/.vscode/launch.json
+++ b/Source/Meadow.Foundation.Core.Samples/Sensors.Temperature.AnalogTemperature_Sample/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}


### PR DESCRIPTION
Part of WildernessLabs/Meadow_Issues#236.

The addition of the `.vscode` folder doesn't appear to impact VS2022 users at all, even with several folders present in a solution.  I confirmed expected debug behavior using only the Blinky C# project, but it worked as expected.