### PR TITLE
TftSpiBase.SetAddressWindow optimizations

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Gc9a01.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Gc9a01.cs
@@ -287,32 +287,6 @@ namespace Meadow.Foundation.Displays
         }
 
         /// <summary>
-        /// Set address window to update
-        /// </summary>
-        /// <param name="x0">Start x position in pixels</param>
-        /// <param name="y0">End x position in pixels</param>
-        /// <param name="x1">Start y position in pixels</param>
-        /// <param name="y1">End y position in pixels</param>
-        protected override void SetAddressWindow(int x0, int y0, int x1, int y1)
-        {
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = Data;
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = Data;
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));    // YSTART
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));    // YEND
-
-            SendCommand(LcdCommand.RAMWR);  // write to RAM
-        }
-
-        /// <summary>
         /// Set the rotation of the display
         /// </summary>
         /// <param name="rotation">The rotation</param>

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Hx8357d.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Hx8357d.cs
@@ -168,32 +168,6 @@ namespace Meadow.Foundation.Displays
         }
 
         /// <summary>
-        /// Set addrees window for display updates
-        /// </summary>
-        /// <param name="x0">X start in pixels</param>
-        /// <param name="y0">Y start in pixels</param>
-        /// <param name="x1">X end in pixels</param>
-        /// <param name="y1">Y end in pixels</param>
-        protected override void SetAddressWindow(int x0, int y0, int x1, int y1)
-        {
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = Data;
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = Data;
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));    // YSTART
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));    // YEND
-
-            SendCommand(LcdCommand.RAMWR);  // write to RAM
-        }
-
-        /// <summary>
         /// Set the display rotation
         /// </summary>
         /// <param name="rotation">The rotation value</param>

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ili9163.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ili9163.cs
@@ -190,32 +190,5 @@ namespace Meadow.Foundation.Displays
 
             dataCommandPort.State = (Data);
         }
-
-        /// <summary>
-        /// Set the address window to update the display
-        /// </summary>
-        /// <param name="x0">X0</param>
-        /// <param name="y0">Y0</param>
-        /// <param name="x1">X1</param>
-        /// <param name="y1">Y1</param>
-        protected override void SetAddressWindow(int x0, int y0, int x1, int y1)
-        {
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = Data;
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = (Data);
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));    // YSTART
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));    // YEND
-
-            dataCommandPort.State = (Command);
-            Write((byte)LcdCommand.RAMWR);  // write to RAM */
-        }
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ili9341.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ili9341.cs
@@ -113,32 +113,6 @@ namespace Meadow.Foundation.Displays
             dataCommandPort.State = Data;
         }
 
-        /// <summary>
-        /// Set addrees window for display updates
-        /// </summary>
-        /// <param name="x0">X start in pixels</param>
-        /// <param name="y0">Y start in pixels</param>
-        /// <param name="x1">X end in pixels</param>
-        /// <param name="y1">Y end in pixels</param>
-        protected override void SetAddressWindow(int x0, int y0, int x1, int y1)
-        {
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = Data;
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = Data;
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));    // YSTART
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));    // YEND
-
-            SendCommand(LcdCommand.RAMWR);  // write to RAM */
-        }
-
         void SendCommand(byte command, byte[] data)
         {
             dataCommandPort.State = Command;

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ili9481.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ili9481.cs
@@ -135,32 +135,6 @@ namespace Meadow.Foundation.Displays
         }
 
         /// <summary>
-        /// Set addrees window for display updates
-        /// </summary>
-        /// <param name="x0">X start in pixels</param>
-        /// <param name="y0">Y start in pixels</param>
-        /// <param name="x1">X end in pixels</param>
-        /// <param name="y1">Y end in pixels</param>
-        protected override void SetAddressWindow(int x0, int y0, int x1, int y1)
-        {
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = Data;
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = Data;
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));    // YSTART
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));    // YEND
-
-            SendCommand(LcdCommand.RAMWR);  // write to RAM
-        }
-
-        /// <summary>
         /// Set the display rotation
         /// </summary>
         /// <param name="rotation">The rotation value</param>

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ili9486.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ili9486.cs
@@ -124,32 +124,6 @@ namespace Meadow.Foundation.Displays
         }
 
         /// <summary>
-        /// Set addrees window for display updates
-        /// </summary>
-        /// <param name="x0">X start in pixels</param>
-        /// <param name="y0">Y start in pixels</param>
-        /// <param name="x1">X end in pixels</param>
-        /// <param name="y1">Y end in pixels</param>
-        protected override void SetAddressWindow(int x0, int y0, int x1, int y1)
-        {
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = Data;
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = Data;
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));    // YSTART
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));    // YEND
-
-            SendCommand(LcdCommand.RAMWR);  // write to RAM
-        }
-
-        /// <summary>
         /// Set the display rotation
         /// </summary>
         /// <param name="rotation">The rotation value</param>

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ili9488.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ili9488.cs
@@ -153,32 +153,6 @@ namespace Meadow.Foundation.Displays
         }
 
         /// <summary>
-        /// Set addrees window for display updates
-        /// </summary>
-        /// <param name="x0">X start in pixels</param>
-        /// <param name="y0">Y start in pixels</param>
-        /// <param name="x1">X end in pixels</param>
-        /// <param name="y1">Y end in pixels</param>
-        protected override void SetAddressWindow(int x0, int y0, int x1, int y1)
-        {
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = Data;
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = Data;
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));    // YSTART
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));    // YEND
-
-            SendCommand(LcdCommand.RAMWR);  // write to RAM
-        }
-
-        /// <summary>
         /// Set the display rotation
         /// </summary>
         /// <param name="rotation">The rotation value</param>

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Rm68140.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Rm68140.cs
@@ -130,32 +130,6 @@ namespace Meadow.Foundation.Displays
         }
 
         /// <summary>
-        /// Set addrees window for display updates
-        /// </summary>
-        /// <param name="x0">X start in pixels</param>
-        /// <param name="y0">Y start in pixels</param>
-        /// <param name="x1">X end in pixels</param>
-        /// <param name="y1">Y end in pixels</param>
-        protected override void SetAddressWindow(int x0, int y0, int x1, int y1)
-        {
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = Data;
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = Data;
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));    // YSTART
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));    // YEND
-
-            SendCommand(LcdCommand.RAMWR);  // write to RAM
-        }
-
-        /// <summary>
         /// Set the display rotation
         /// </summary>
         /// <param name="rotation">The rotation value</param>

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/S6D02A1.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/S6D02A1.cs
@@ -124,33 +124,6 @@ namespace Meadow.Foundation.Displays
         }
 
         /// <summary>
-        /// Set addrees window for display updates
-        /// </summary>
-        /// <param name="x0">X start in pixels</param>
-        /// <param name="y0">Y start in pixels</param>
-        /// <param name="x1">X end in pixels</param>
-        /// <param name="y1">Y end in pixels</param>
-        protected override void SetAddressWindow(int x0, int y0, int x1, int y1)
-        {
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = (Data);
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = (Data);
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));    // YSTART
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));    // YEND
-
-            dataCommandPort.State = (Command);
-            Write((byte)LcdCommand.RAMWR);  // write to RAM */
-        }
-
-        /// <summary>
         /// Set the display rotation
         /// </summary>
         /// <param name="rotation">The rotation value</param>

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ssd1331.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/Ssd1331.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Foundation.Graphics;
+﻿using System;
+using Meadow.Foundation.Graphics;
 using Meadow.Hardware;
 
 namespace Meadow.Foundation.Displays
@@ -126,7 +127,7 @@ namespace Meadow.Foundation.Displays
         }
 
         /// <summary>
-        /// Set addrees window for display updates
+        /// Set address window for display updates
         /// </summary>
         /// <param name="x0">X start in pixels</param>
         /// <param name="y0">Y start in pixels</param>

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/St7735.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/St7735.cs
@@ -382,22 +382,8 @@ namespace Meadow.Foundation.Displays
 
             x1 += xOffset;
             y1 += yOffset;
-
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = Data;
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = Data;
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));   // YSTART 
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));   // YEND
-
-            SendCommand(LcdCommand.RAMWR);  // write to RAM
+            
+            base.SetAddressWindow(x0, y0, x1, y1);
         }
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/St7789.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/St7789.cs
@@ -9,8 +9,6 @@ namespace Meadow.Foundation.Displays
     /// </summary>
     public class St7789 : TftSpiBase, IRotatableDisplay
     {
-        private readonly byte[] _setAddressBuffer = new byte[4];
-        
         /// <summary>
         /// The default display color mode
         /// </summary>
@@ -156,23 +154,8 @@ namespace Meadow.Foundation.Displays
 
             x1 += xOffset;
             y1 += yOffset;
-
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = Data;
-            _setAddressBuffer[0] = (byte)(x0 >> 8);
-            _setAddressBuffer[1] = (byte)(x0 & 0xff); // XSTART
-            _setAddressBuffer[2] = (byte)(x1 >> 8);
-            _setAddressBuffer[3] = (byte)(x1 & 0xff); // XEND
-            Write(_setAddressBuffer);
             
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = Data;
-            _setAddressBuffer[0] = (byte)(y0 >> 8);
-            _setAddressBuffer[0] = (byte)(y0 & 0xff); // XEND
-            _setAddressBuffer[0] = (byte)(y1 >> 8);
-            _setAddressBuffer[0] = (byte)(y1 & 0xff); // YEND
-            
-            SendCommand(LcdCommand.RAMWR);  // write to RAM
+            base.SetAddressWindow(x0, y0, x1, y1);
         }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/St7789.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/St7789.cs
@@ -9,6 +9,8 @@ namespace Meadow.Foundation.Displays
     /// </summary>
     public class St7789 : TftSpiBase, IRotatableDisplay
     {
+        private readonly byte[] _setAddressBuffer = new byte[4];
+        
         /// <summary>
         /// The default display color mode
         /// </summary>
@@ -157,18 +159,19 @@ namespace Meadow.Foundation.Displays
 
             SendCommand(LcdCommand.CASET);  // column addr set
             dataCommandPort.State = Data;
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
+            _setAddressBuffer[0] = (byte)(x0 >> 8);
+            _setAddressBuffer[1] = (byte)(x0 & 0xff); // XSTART
+            _setAddressBuffer[2] = (byte)(x1 >> 8);
+            _setAddressBuffer[3] = (byte)(x1 & 0xff); // XEND
+            Write(_setAddressBuffer);
+            
             SendCommand(LcdCommand.RASET);  // row addr set
             dataCommandPort.State = Data;
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));    // YSTART
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));    // YEND
-
+            _setAddressBuffer[0] = (byte)(y0 >> 8);
+            _setAddressBuffer[0] = (byte)(y0 & 0xff); // XEND
+            _setAddressBuffer[0] = (byte)(y1 >> 8);
+            _setAddressBuffer[0] = (byte)(y1 & 0xff); // YEND
+            
             SendCommand(LcdCommand.RAMWR);  // write to RAM
         }
 

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/St7796s.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/St7796s.cs
@@ -159,32 +159,6 @@ namespace Meadow.Foundation.Displays
         }
 
         /// <summary>
-        /// Set addrees window for display updates
-        /// </summary>
-        /// <param name="x0">X start in pixels</param>
-        /// <param name="y0">Y start in pixels</param>
-        /// <param name="x1">X end in pixels</param>
-        /// <param name="y1">Y end in pixels</param>
-        protected override void SetAddressWindow(int x0, int y0, int x1, int y1)
-        {
-            SendCommand(LcdCommand.CASET);  // column addr set
-            dataCommandPort.State = Data;
-            Write((byte)(x0 >> 8));
-            Write((byte)(x0 & 0xff));   // XSTART 
-            Write((byte)(x1 >> 8));
-            Write((byte)(x1 & 0xff));   // XEND
-
-            SendCommand(LcdCommand.RASET);  // row addr set
-            dataCommandPort.State = Data;
-            Write((byte)(y0 >> 8));
-            Write((byte)(y0 & 0xff));    // YSTART
-            Write((byte)(y1 >> 8));
-            Write((byte)(y1 & 0xff));    // YEND
-
-            SendCommand(LcdCommand.RAMWR);  // write to RAM
-        }
-
-        /// <summary>
         /// Set the display rotation
         /// </summary>
         /// <param name="rotation">The rotation value</param>


### PR DESCRIPTION
The `SetAddressWindow()` function sends data for caset and raset commands one byte at a time. This causes a loss of performance due to the overhead of loading each individual byte to the SPI bus one at a time.  

Combining these 4 bytes into 1 SPI call brings the SetWindowAddress timing to go from ~5ms to 2ms.

This PR also moves the logic of `SetWindowAddress()` into the `TftSpiBase` base class, since most displays re-use them.