### PR TITLE
Fix space padding when showing * or > indicators

### DIFF
--- a/Source/Meadow.Foundation.Libraries_and_Frameworks/Displays.TextDisplayMenu/Driver/TextDisplayMenu.cs
+++ b/Source/Meadow.Foundation.Libraries_and_Frameworks/Displays.TextDisplayMenu/Driver/TextDisplayMenu.cs
@@ -65,6 +65,7 @@ namespace Meadow.Foundation.Displays.UI
         /// <param name="showBackOnRoot">True to show Back item on root menu</param>
         public TextDisplayMenu(ITextDisplay display, MenuItem[] menuItems, bool showBackOnRoot = false)
         {
+            this.showBackOnRoot = showBackOnRoot;
             Init(display, CreateMenuPage(menuItems, showBackOnRoot));
         }
 
@@ -212,7 +213,7 @@ namespace Meadow.Foundation.Displays.UI
             if (isSelected || item.HasSubItems)
             {
                 // calculate any neccessary padding to put selector on far right
-                int paddingLength = (display.DisplayConfig.Width - 1 - displayText.Length);
+                int paddingLength = (display.DisplayConfig.Width / display.DisplayConfig.FontScale - 1 - displayText.Length);
                 string padding = string.Empty;
                 if (paddingLength > 0) { padding = new string(' ', paddingLength); }
 


### PR DESCRIPTION
Noticed in [Clima Hack Kit](https://github.com/WildernessLabs/Clima/tree/develop/Source/Additional%20Samples/Clima_HackKit_Demo) sample, the item selected indicator (*) was being drawn outside of the screen on the ST7789 display due to selecting a Factor Scale of 2, so it was not taken in consideration when calculating the number of ` ` for the padding between the item element and the selected (*) symbol.

