### PR TITLE
Masking CTRL_GAS_1 for Bme68x in HeaterProfile

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Sensors.Atmospheric.Bme68x/Driver/Bme68x.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Atmospheric.Bme68x/Driver/Bme68x.cs
@@ -86,7 +86,7 @@ namespace Meadow.Foundation.Sensors.Atmospheric
                     }
 
                     var profile = busComms.ReadRegister((byte)Registers.CTRL_GAS_1);
-                    profile = (byte)((profile & 0x0F) | (byte)value);
+                    profile = (byte)((profile & 0xF0) | (byte)value);
 
                     busComms.WriteRegister((byte)Registers.CTRL_GAS_1, profile);
 


### PR DESCRIPTION
Masking CTRL_GAS_1 for Bme68x in HeaterProfile

The mask should allow to set nb_conv<3:0> bits as per datasheet.

From BME688 datasheet:
![image](https://github.com/WildernessLabs/Meadow.Foundation/assets/10052368/61ea65da-9d0b-411f-bbe7-352091634d32)
![image](https://github.com/WildernessLabs/Meadow.Foundation/assets/10052368/4d9faaee-3fc3-47f2-8fbe-ab12ebfa05a1)

However, for BME688 it seems I have to read the values from different registers compared to 680.

And also the gas resistance calculation seems to be different too:

```csharp
    Resistance CalculateGasResistance_BME688(ushort adcGasRes, byte gasRange)
    {
        if (calibration == null) throw new NullReferenceException("Calibration must be defined");

        var var1 = ((uint)262144) >> gasRange;
        var var2 = ((int)adcGasRes) - 512;
        var2 *= 3;
        var2 = 4096 + var2;
        var gasResistance = 1000000.0 * var1 / var2;

        return new Resistance(gasResistance, Resistance.UnitType.Ohms);
```

Registers are different too:

```csharp
        GAS_RES = 0x2C,
        GAS_RANGE = 0x2D,
```

And GasConversionIsEnabled needs to set the 5th bit instead of the 4th. 

I did not include this in the PR, but I also needed to get things working. I would be happy to include these changes in this PR (I suppose I would need to make a few members virtual and overridden in the actual classes, but I did not want to do it until you agree with this proposal.

cc. @adrianstevens 