### PR TITLE
Bugfix: Array indexing at non existent item

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Pcx857x/Driver/Drivers/Extras/Pcx8574.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Pcx857x/Driver/Drivers/Extras/Pcx8574.cs
@@ -158,7 +158,7 @@ namespace Meadow.Foundation.ICs.IOExpanders
         {
             Span<byte> buffer = stackalloc byte[1];
             i2cComms.Read(buffer);
-            return buffer[1];
+            return buffer[0];
         }
 
         /// <summary>


### PR DESCRIPTION
An array with a length of 1 cannot be accessed at index 1 but only at 0.