### PR TITLE
Tuck log output to trace

### DIFF
--- a/Source/Meadow.Foundation.Libraries_and_Frameworks/Sensors.Location.Gnss.NmeaProcessor/Driver/NmeaProcessor.cs
+++ b/Source/Meadow.Foundation.Libraries_and_Frameworks/Sensors.Location.Gnss.NmeaProcessor/Driver/NmeaProcessor.cs
@@ -46,7 +46,7 @@ namespace Meadow.Foundation.Sensors.Location.Gnss
         /// <param name="decoder">NMEA decoder</param>
         public void RegisterDecoder(INmeaDecoder decoder)
         {
-            Resolver.Log.Info($"Registering decoder: {decoder.Prefix}");
+            Resolver.Log.Trace($"Registering decoder: {decoder.Prefix}");
             if (decoders.ContainsKey(decoder.Prefix))
             {
                 throw new Exception(decoder.Prefix + " already registered.");


### PR DESCRIPTION
Normally id like internal outputs from drivers in the Trace level to keep Info level clean for the user.