### PR TITLE
Support for UART control mode for a02yyuw distance sensor

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.A02yyuw/Driver/Readme.md
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.A02yyuw/Driver/Readme.md
@@ -2,19 +2,31 @@
 
 **A02yyuw serial ultrasonic distance sensor**
 
-The **A02yyuw** library is included in the **Meadow.Foundation.Sensors.Distance.A02yyuw** nuget package and is designed for the [Wilderness Labs](www.wildernesslabs.co) Meadow .NET IoT platform.
+### Pinout for Sensor:
+1. (red) VCC power input 3- 5 V
+2. (black) ground
+3. (yellow) Rx pin function depends on output mode
+4. (white) Tx pin function depends on output mode
 
-This driver is part of the [Meadow.Foundation](https://developer.wildernesslabs.co/Meadow/Meadow.Foundation/) peripherals library, an open-source repository of drivers and libraries that streamline and simplify adding hardware to your C# .NET Meadow IoT applications.
+The A02 series supports 5 different modes of operation (PWM output, UART Controlled output,UART Auto output, Switched output).
+The Rx and Tx pin function corresponds to the output mode selected before ordering, and can not be changed. The **A02yyuw** library supports the 
+UART Controlled output and UART Auto output of the A02, which can be selected in software.
+
+In UART Auto mode, when the Rx pin is held low, the module outputs real-time values on the Tx pin with a response time of 100ms.
+When pin(RX)is held high, the module outputs processed values, and the data is more stable. The response time is 100~500ms. The **A02yyuw** library
+keeps Rx high in UART Auto output, so processed values are obtained.
+
+In UART Controlled mode, the module wil perform a distance detection and send data on the Tx pin after the Rx pin receives a falling edge pulse.
+The period between Rx pulses must be greater than 70ms. The **A02yyuw** library sends a pulse by writing a byte of data to the serial port.
+
+The **A02yyuw** library is designed for the [Wilderness Labs](www.wildernesslabs.co) Meadow .NET IoT platform and is part of [Meadow.Foundation](https://developer.wildernesslabs.co/Meadow/Meadow.Foundation/).
+
+The **Meadow.Foundation** peripherals library is an open-source repository of drivers and libraries that streamline and simplify adding hardware to your C# .NET Meadow IoT application.
 
 For more information on developing for Meadow, visit [developer.wildernesslabs.co](http://developer.wildernesslabs.co/).
 
 To view all Wilderness Labs open-source projects, including samples, visit [github.com/wildernesslabs](https://github.com/wildernesslabs/).
 
-## Installation
-
-You can install the library from within Visual studio using the the NuGet Package Manager or from the command line using the .NET CLI:
-
-`dotnet add package Meadow.Foundation.Sensors.Distance.A02yyuw`
 ## Usage
 
 ```csharp
@@ -73,20 +85,3 @@ private void A02yyuw_DistanceUpdated(object sender, IChangeResult<Length> e)
 ## Need Help?
 
 If you have questions or need assistance, please join the Wilderness Labs [community on Slack](http://slackinvite.wildernesslabs.co/).
-## About Meadow
-
-Meadow is a complete, IoT platform with defense-grade security that runs full .NET applications on embeddable microcontrollers and Linux single-board computers including Raspberry Pi and NVIDIA Jetson.
-
-### Build
-
-Use the full .NET platform and tooling such as Visual Studio and plug-and-play hardware drivers to painlessly build IoT solutions.
-
-### Connect
-
-Utilize native support for WiFi, Ethernet, and Cellular connectivity to send sensor data to the Cloud and remotely control your peripherals.
-
-### Deploy
-
-Instantly deploy and manage your fleet in the cloud for OtA, health-monitoring, logs, command + control, and enterprise backend integrations.
-
-

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.A02yyuw/Samples/A02yyuw_Sample/MeadowApp.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.A02yyuw/Samples/A02yyuw_Sample/MeadowApp.cs
@@ -1,4 +1,6 @@
-﻿using Meadow;
+﻿//#define DEVICE_FEATHER
+#define DEVICE_PROJECT_LAB
+using Meadow;
 using Meadow.Devices;
 using Meadow.Foundation.Sensors.Distance;
 using Meadow.Units;
@@ -8,7 +10,12 @@ using System.Threading.Tasks;
 namespace A02yyuw_Sample
 {
     // Change F7FeatherV2 to F7FeatherV1 for V1.x boards
+#if DEVICE_FEATHER          // Feather: Change F7FeatherV2 to F7FeatherV1 for V1.x boards
+    public class MeadowApp : App<F7FeatherV2>
+#endif
+#if DEVICE_PROJECT_LAB      //ProjectLab: uses an F7CoreComputeV2 board
     public class MeadowApp : App<F7CoreComputeV2>
+#endif
     {
         //<!=SNIP=>
 
@@ -18,7 +25,7 @@ namespace A02yyuw_Sample
         {
             Resolver.Log.Info("Initialize...");
 
-            a02yyuw = new A02yyuw(Device, Device.PlatformOS.GetSerialPortName("COM4"));
+            a02yyuw = new A02yyuw(Device, Device.PlatformOS.GetSerialPortName("COM4"), A02yyuw.MODE_UART_CONTROL);
 
             var consumer = A02yyuw.CreateObserver(
                 handler: result =>


### PR DESCRIPTION
Added support for UART control mode for a02yyuw distance sensor. This involved sending a byte to the device before trying to read it. Added an optional parameter to constructors to choose between auto and control mode