### PR TITLE
Escapes special characters in a string to ensure it is JSON-compliant

### DIFF
--- a/Source/Meadow.Foundation.Libraries_and_Frameworks/Serialization.MicroJson/Driver/MicroJson.cs
+++ b/Source/Meadow.Foundation.Libraries_and_Frameworks/Serialization.MicroJson/Driver/MicroJson.cs
@@ -32,6 +32,32 @@ public static partial class MicroJson
     }
 
     /// <summary>
+    /// Escapes special characters in a string to ensure it is JSON-compliant.
+    /// </summary>
+    /// <param name="value">The string to escape.</param>
+    /// <returns>The escaped string with special characters properly encoded.</returns>
+    /// <remarks>
+    /// This method handles the following special characters:
+    /// - Double quotes (") are escaped as \".
+    /// - Backslashes (\) are escaped as \\.
+    /// - Newlines (\n) are escaped as \\n.
+    /// - Carriage returns (\r) are escaped as \\r.
+    /// - Tabs (\t) are escaped as \\t.
+    /// - Backspaces (\b) are escaped as \\b.
+    /// - Form feeds (\f) are escaped as \\f.
+    /// </remarks>
+    public static string EscapeString(string value)
+    {
+        return "\"" + value.Replace("\\", "\\\\")
+                        .Replace("\"", "\\\"")
+                        .Replace("\n", "\\n")
+                        .Replace("\r", "\\r")
+                        .Replace("\t", "\\t")
+                        .Replace("\b", "\\b")
+                        .Replace("\f", "\\f") + "\"";
+    }
+
+    /// <summary>
     /// Converts an object to a JSON string.
     /// </summary>
     /// <param name="o">The value to convert.</param>
@@ -59,11 +85,9 @@ public static partial class MicroJson
             case TypeCode.Boolean:
                 return (bool)o ? "true" : "false";
             case TypeCode.String:
-                return $"\"{o}\""
-                    .Replace("\n", "\\n")
-                    .Replace("\r", "\\r");
+                return EscapeString((string)o);
             case TypeCode.Char:
-                return $"\"{o}\"";
+                return EscapeString(o.ToString());
             case TypeCode.Single:
             case TypeCode.Double:
             case TypeCode.Decimal:


### PR DESCRIPTION
**Summary**
As mentioned in [a private slack discussion](https://wildernesslabs.slack.com/archives/C05TXSF4B8E/p1716246927429179), the `Resolver.JsonSerializer.Serialize` in the `MeadowCloudConnectionService` doesn't seem to properly serialize some JSONs. 

So, this PR aims to escape special characters like double quotes ("), backslashes (\), newlines (\n), carriage returns (\r), tabs (\t), backspaces (\b), and form feeds (\f) to ensure that the resulting JSON string is valid and can be properly parsed by a JSON parser.