### PR TITLE
Exception altering Parity before setting DataBits

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Sc16is7x2/Driver/Sc16is7x2.Sc16is7x2Channel.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Sc16is7x2/Driver/Sc16is7x2.Sc16is7x2Channel.cs
@@ -162,6 +162,8 @@ public partial class Sc16is7x2
 
         private void Initialize(int baudRate, int dataBits, Parity parity, StopBits stopBits)
         {
+            _dataBits = dataBits;
+            _stopBits = stopBits;
             _controller.Reset();
             _controller.EnableFifo(_channel);
             _baudRate = _controller.SetBaudRate(_channel, baudRate);


### PR DESCRIPTION
Currently if you try to call 
                `port.Parity = Parity.Even;`
before first calling 
                `port.DataBits = 8;`
the application will crash as `_dataBits` have not been set locally when initialised. `StopBits` is the same. 