### PR TITLE
Change TftSpiBase displays to use SpiBus.Write instead of Exchange

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/St7789.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/Drivers/St7789.cs
@@ -45,7 +45,7 @@ namespace Meadow.Foundation.Displays
         /// <param name="width">Width of display in pixels</param>
         /// <param name="height">Height of display in pixels</param>
         /// <param name="colorMode">The color mode to use for the display buffer</param>
-        public St7789(ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin resetPin,
+        public St7789(ISpiBus spiBus, IPin chipSelectPin, IPin dcPin, IPin? resetPin,
             int width, int height, ColorMode colorMode = ColorMode.Format12bppRgb444)
             : base(spiBus, chipSelectPin, dcPin, resetPin, width, height, colorMode)
         {
@@ -63,7 +63,7 @@ namespace Meadow.Foundation.Displays
         /// <param name="height">Height of display in pixels</param>
         /// <param name="colorMode">The color mode to use for the display buffer</param>
         public St7789(ISpiBus spiBus, IDigitalOutputPort chipSelectPort,
-                IDigitalOutputPort dataCommandPort, IDigitalOutputPort resetPort,
+                IDigitalOutputPort dataCommandPort, IDigitalOutputPort? resetPort,
                 int width, int height, ColorMode colorMode = ColorMode.Format12bppRgb444) :
             base(spiBus, chipSelectPort, dataCommandPort, resetPort, width, height, colorMode)
         {

--- a/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/TftSpiBase.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.TftSpi/Driver/TftSpiBase.cs
@@ -110,11 +110,6 @@ namespace Meadow.Foundation.Displays
         protected IPixelBuffer imageBuffer = default!;
 
         /// <summary>
-        /// The read buffer
-        /// </summary>
-        protected Memory<byte> readBuffer;
-
-        /// <summary>
         /// Data convenience bool
         /// </summary>
         protected const bool Data = true;
@@ -271,7 +266,6 @@ namespace Meadow.Foundation.Displays
             {
                 imageBuffer = new BufferRgb444(width, height);
             }
-            readBuffer = new byte[imageBuffer.ByteCount];
         }
 
         /// <summary>
@@ -415,7 +409,7 @@ namespace Meadow.Foundation.Displays
 
             dataCommandPort.State = Data;
 
-            spiDisplay.Bus.Exchange(chipSelectPort, imageBuffer.Buffer, readBuffer.Span);
+            spiDisplay.Bus.Write(chipSelectPort, imageBuffer.Buffer);
         }
 
         /// <summary>
@@ -467,10 +461,9 @@ namespace Meadow.Foundation.Displays
             {
                 int sourceIndex = (int)((y * Width + left) * bytesPerPixel);
 
-                spiDisplay.Bus.Exchange(
+                spiDisplay.Bus.Write(
                     chipSelectPort,
-                    imageBuffer.Buffer[sourceIndex..(sourceIndex + len)],
-                    readBuffer.Span[0..len]);
+                    imageBuffer.Buffer[sourceIndex..(sourceIndex + len)]);
             }
         }
 

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/Ft232h_Sample/Ft232h_Sample.csproj
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/Ft232h_Sample/Ft232h_Sample.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Displays.TftSpi\Driver\Displays.TftSpi.csproj" />
     <ProjectReference Include="..\..\..\ICs.ADCs.Mcp3xxx\Driver\ICs.ADC.Mcp3xxx.csproj" />
     <ProjectReference Include="..\..\..\Sensors.Light.Veml7700\Driver\Sensors.Light.Veml7700.csproj" />
     <ProjectReference Include="..\..\Driver\ICs.IOExpanders.Ftxxxx.csproj" />

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/Ft232h_Sample/Program.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/Ft232h_Sample/Program.cs
@@ -1,8 +1,11 @@
 ﻿// See https://aka.ms/new-console-template for more information
 using Meadow;
+using Meadow.Foundation.Displays;
+using Meadow.Foundation.Graphics;
 using Meadow.Foundation.ICs.IOExpanders;
 using Meadow.Foundation.Sensors.Light;
 using Meadow.Hardware;
+using Meadow.Peripherals.Displays;
 using System.Diagnostics;
 
 Console.WriteLine("HELLO FROM THE WILDERNESS FT232H DRIVER!");
@@ -12,7 +15,37 @@ var expander = FtdiExpanderCollection.Devices[0];
 
 //await TestGpio(FtdiExpanderCollection.Devices);
 //await TestI2C(FtdiExpanderCollection.Devices[0]);
-await TestSPI(FtdiExpanderCollection.Devices[0]);
+//await TestSPI(FtdiExpanderCollection.Devices[0]);
+await TestSPIDisplay(FtdiExpanderCollection.Devices[0]);
+
+async Task TestSPIDisplay(FtdiExpander expander)
+{
+    var display = new St7789
+        (
+            spiBus: expander.CreateSpiBus(),
+            chipSelectPin: expander.Pins.D0,
+            dcPin: expander.Pins.D1,
+            resetPin: null,
+            135, 240
+        );
+
+    var microGraphics = new MicroGraphics(display)
+    {
+        CurrentFont = new Font12x16(),
+        Rotation = RotationType._270Degrees
+    };
+
+    microGraphics.Clear();
+    microGraphics.DrawText(0, 0, "Loading Menu");
+    microGraphics.Show();
+
+    while (true)
+    {
+        Debug.WriteLine("Sleeping...");
+
+        await Task.Delay(1000);
+    }
+}
 
 async Task TestSPI(FtdiExpander expander)
 {


### PR DESCRIPTION
Fix for https://github.com/WildernessLabs/Meadow_Issues/issues/826

Also changed API for ST7789 to have the reset pin optional (nullable) (it is optional when driving the display, so it should be nullable IMO)