### PR TITLE
Fix speed calculation in SwitchingAnemometer

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Sensors.Weather.SwitchingAnemometer/Driver/SwitchingAnemometer.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Weather.SwitchingAnemometer/Driver/SwitchingAnemometer.cs
@@ -22,7 +22,22 @@ namespace Meadow.Foundation.Sensors.Weather
         /// <summary>
         /// Time to wait if no events come in to register a zero speed wind
         /// </summary>
+        /// <remarks>
+        /// This value determines the minimum wind speed that can be measured.
+        /// i.e. minimum speed is KmhPerSwitchPerSecond / NoWindTimeout(seconds)
+        /// e.g. (2.4 km/hr/s) / (4s) = 600 m/s 
+        /// <see cref="KmhPerSwitchPerSecond"/>
+        /// </remarks>
         public TimeSpan NoWindTimeout { get; set; } = TimeSpan.FromSeconds(4);
+
+        /// <summary>
+        /// Define the theoretical maximum speed that can be measured. Higher speeds are ignored. 
+        /// </summary>
+        /// <remarks>
+        /// Category 5 Hurricane is > 300 km/hr. 
+        /// </remarks>
+        public Speed? MaxSpeed { get; set; } = new Speed(500, SU.KilometersPerHour);
+
 
         /// <summary>
         /// Time to capture samples for a one time Read if IsSampling is false
@@ -49,7 +64,7 @@ namespace Meadow.Foundation.Sensors.Weather
         /// once per second. Used to calculate the wind speed based on the time
         /// duration between switch events. Default is `2.4kmh`.
         /// </summary>
-        public float KmhPerSwitchPerSecond { get; set; } = 2.4f;
+        public double KmhPerSwitchPerSecond { get; set; } = 2.4;
 
         private readonly IDigitalInterruptPort inputPort;
         private bool running = false;
@@ -70,6 +85,10 @@ namespace Meadow.Foundation.Sensors.Weather
         /// on the device.
         /// </summary>
         /// <param name="digitalInputPin"></param>
+        /// <remarks>
+        /// Debounce will limit upper speed to approximately half of (2.4/0.002) = 1200 km/hr.
+        /// i.e. +/- 600 km/hr assuming events can be raised that quickly. 
+        /// </remarks>
         public SwitchingAnemometer(IPin digitalInputPin)
             : this(digitalInputPin.CreateDigitalInterruptPort(InterruptMode.EdgeFalling,
                                                             ResistorMode.InternalPullUp,
@@ -155,28 +174,45 @@ namespace Meadow.Foundation.Sensors.Weather
 
             lock (samples)
             {
-                if (samples?.Count > 0 && (DateTime.UtcNow - samples?.Peek().New.Time > NoWindTimeout))
+                int count = 0;
+
+                if (samples?.Count > 0 && samples?.Peek().Delta > NoWindTimeout)
                 {   //we've exceeded the no wind interval time 
                     samples?.Clear(); //will force a zero reading
+                    return new Speed(0);
                 }
-                // if we've reached our sample count
-                else if (samples?.Count >= SampleCount)
+
+                // do we have enough samples to calculate a result?
+                if (samples?.Count >= SampleCount)
                 {
-                    float speedSum = 0f;
+                    double speedSum = 0f;
 
                     // sum up the speeds
                     foreach (var sample in samples)
-                    {   // skip the first (old will be null)
-                        if (sample.Old is { } old)
+                    {   
+                        // Check delta is not null and reasonable. (0 ms would be infinite speed. What is a reasonable maximum speed?)
+                        if (sample.Delta is { Milliseconds: > 0 } delta)
                         {
-                            speedSum += SwitchIntervalToKmh(sample.New.Time - old.Time);
+                            double speed = SwitchIntervalToKmh(delta);
+
+                            // skip speeds that are unreasonably high
+                            if (MaxSpeed?.KilometersPerHour >= speed )
+                            {
+                                speedSum += speed;
+                                count++;
+
+                                //Resolver.Log.Info($"count {count} : delta={delta} speed={speed:N4} speedSum={speedSum:N4} sample={sample} ");
+                            }
                         }
                     }
 
-                    // average the speeds
-                    float oversampledSpeed = speedSum / (samples.Count - 1);
-
-                    return new Speed(oversampledSpeed, SU.KilometersPerHour);
+                    // do we have enough samples to report an observation?
+                    if (count >= SampleCount)
+                    {
+                        // average the speeds
+                        double oversampledSpeed = speedSum / count;
+                        return new Speed(oversampledSpeed, SU.KilometersPerHour);
+                    }
                 }
             }
 
@@ -189,9 +225,9 @@ namespace Meadow.Foundation.Sensors.Weather
         /// </summary>
         /// <param name="interval">The interval between signals</param>
         /// <returns></returns>
-        protected float SwitchIntervalToKmh(TimeSpan interval)
+        protected double SwitchIntervalToKmh(TimeSpan interval)
         {
-            return KmhPerSwitchPerSecond / (float)interval.TotalSeconds;
+            return KmhPerSwitchPerSecond / (double)interval.TotalSeconds;
         }
 
         ///<inheritdoc/>

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Weather.SwitchingAnemometer/Samples/SwitchingAnemometer_Sample/MeadowApp.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Weather.SwitchingAnemometer/Samples/SwitchingAnemometer_Sample/MeadowApp.cs
@@ -1,21 +1,32 @@
-﻿using Meadow;
+﻿using System.IO;
+using Meadow;
 using Meadow.Devices;
 using Meadow.Foundation.Sensors.Weather;
 using System.Threading.Tasks;
+using Meadow.Hardware;
+using Meadow.Units;
 
 namespace MeadowApp
 {
-    public class MeadowApp : App<F7FeatherV2>
+    public class MeadowApp : App<F7CoreComputeV2>
     {
         //<!=SNIP=>
 
-        SwitchingAnemometer anemometer;
+        private SwitchingAnemometer anemometer;
 
         public override Task Initialize()
         {
             Resolver.Log.Info("Initialize...");
 
             anemometer = new SwitchingAnemometer(Device.Pins.A01);
+
+            // Uncomment to test SwitchingAnemometer implementation.
+            // Assumes external wire connected between a PWM capable output and the above configured 
+            // SwitchingAnemometer input. 
+            //double speed = 24; // km/hr
+            //double frequency = speed / (anemometer.KmhPerSwitchPerSecond);
+            //IPwmPort pwm = Device.CreatePwmPort(Device.Pins.D20, new Frequency(frequency, Frequency.UnitType.Hertz));
+            //pwm.Start();
 
             //==== classic events example
             anemometer.Updated += (sender, result) =>


### PR DESCRIPTION
***Driver***
Use the Delta property of the observed DigitalPortResult to determine interval from one edge to the next. 
Ignore impossibly high speeds set by new property MaxSpeed, defaults to 500 km/hr.
Minor code refactor to make code execution clearer that speed returned is zero if to much time between samples, to few samples, or speed is too high.
Add clarification <remarks> to some comments

***Sample***
Added commented code for testing the SwitchingAnemometer by driving the input from a PWM port running at set frequency. 