### PR TITLE
Created an FTx EEPROM Programmer

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Driver/Drivers/Ft2232H.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Driver/Drivers/Ft2232H.cs
@@ -1,0 +1,33 @@
+using Meadow.Hardware;
+
+namespace Meadow.Foundation.ICs.IOExpanders;
+
+/// <summary>
+/// Represents an FT2232H USB IO expander (high-speed dual-channel with MPSSE support)
+/// </summary>
+public class Ft2232H : FtdiExpander
+{
+    internal Ft2232H()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override II2cBus CreateI2cBus(int channel = 0, I2cBusSpeed busSpeed = I2cBusSpeed.Standard)
+    {
+        // FT2232H supports MPSSE on both channels A and B
+        // TODO: Add channel validation and selection
+        var bus = new FtMpsseI2cBus(this, busSpeed);
+        bus.Configure();
+        return bus;
+    }
+
+    /// <inheritdoc/>
+    public override ISpiBus CreateSpiBus(int channel, SpiClockConfiguration configuration)
+    {
+        // FT2232H supports MPSSE on both channels A and B
+        // TODO: Add channel validation and selection
+        var bus = new FtMpsseSpiBus(this, configuration);
+        bus.Configure();
+        return bus;
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Driver/FtdiEeprom.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Driver/FtdiEeprom.cs
@@ -1,0 +1,387 @@
+using System;
+using System.Runtime.InteropServices;
+using static Meadow.Foundation.ICs.IOExpanders.Native.Ftd2xx;
+
+namespace Meadow.Foundation.ICs.IOExpanders;
+
+/// <summary>
+/// FTDI EEPROM programming utilities
+/// </summary>
+public static class FtdiEeprom
+{
+    /// <summary>
+    /// Opens an FTDI device by index for EEPROM operations
+    /// </summary>
+    /// <param name="index">Device index</param>
+    /// <returns>Device handle</returns>
+    public static IntPtr OpenDevice(uint index)
+    {
+        var status = FT_Open(index, out IntPtr handle);
+        Native.CheckStatus(status);
+        return handle;
+    }
+
+    /// <summary>
+    /// Closes an FTDI device
+    /// </summary>
+    /// <param name="handle">Device handle from OpenDevice</param>
+    public static void CloseDevice(IntPtr handle)
+    {
+        var status = FT_Close(handle);
+        Native.CheckStatus(status);
+    }
+
+    /// <summary>
+    /// Attempts to open a device by location ID (useful for recovery)
+    /// </summary>
+    /// <param name="locationId">USB location ID</param>
+    /// <returns>Device handle if successful, IntPtr.Zero if failed</returns>
+    public static IntPtr TryOpenByLocation(uint locationId)
+    {
+        var status = FT_OpenEx(locationId, 4, out IntPtr handle); // 4 = FT_OPEN_BY_LOCATION
+        return (status == Native.FT_STATUS.FT_OK) ? handle : IntPtr.Zero;
+    }
+
+    /// <summary>
+    /// Resets an FTDI device
+    /// </summary>
+    /// <param name="handle">Device handle</param>
+    public static void ResetDevice(IntPtr handle)
+    {
+        var status = FT_ResetDevice(handle);
+        // Don't check status - reset may cause device to disconnect
+    }
+
+    /// <summary>
+    /// Diagnostic test: Try to read EEPROM using FT_EE_Read (FT232H API)
+    /// </summary>
+    /// <param name="handle">Device handle</param>
+    /// <returns>Tuple of (success, errorMessage, version, vid, pid)</returns>
+    public static (bool success, string error, uint version, ushort vid, ushort pid) TestFtEeRead(IntPtr handle)
+    {
+        try
+        {
+            var programData = new FT_PROGRAM_DATA();
+            var status = FT_EE_Read(handle, ref programData);
+            
+            if (status == Native.FT_STATUS.FT_OK)
+            {
+                return (true, string.Empty, programData.Version, programData.VendorId, programData.ProductId);
+            }
+            else
+            {
+                return (false, $"FT_EE_Read returned: {status}", 0, 0, 0);
+            }
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Exception: {ex.Message}", 0, 0, 0);
+        }
+    }
+
+    /// <summary>
+    /// EEPROM data structure for FT2232H and compatible devices
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+    public struct EepromData
+    {
+        /// <summary>Header signature 1 - must be 0x00000000</summary>
+        public uint Signature1;
+        
+        /// <summary>Header signature 2 - must be 0xFFFFFFFF</summary>
+        public uint Signature2;
+        
+        /// <summary>EEPROM version - must be 3 for FT2232H</summary>
+        public uint Version;
+        
+        /// <summary>USB Vendor ID (typically 0x0403 for FTDI)</summary>
+        public ushort VendorId;
+        
+        /// <summary>USB Product ID</summary>
+        public ushort ProductId;
+        
+        /// <summary>Manufacturer string</summary>
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string Manufacturer;
+        
+        /// <summary>Manufacturer ID string</summary>
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 16)]
+        public string ManufacturerId;
+        
+        /// <summary>Device description string</summary>
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
+        public string Description;
+        
+        /// <summary>Serial number string</summary>
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 16)]
+        public string SerialNumber;
+        
+        /// <summary>Maximum power consumption in mA</summary>
+        public ushort MaxPower;
+        
+        /// <summary>Plug and Play enabled (1) or disabled (0)</summary>
+        public ushort PnP;
+        
+        /// <summary>Self powered (1) or bus powered (0)</summary>
+        public ushort SelfPowered;
+        
+        /// <summary>Remote wakeup capable (1) or not (0)</summary>
+        public ushort RemoteWakeup;
+        
+        /// <summary>Pull down enabled</summary>
+        public byte PullDownEnable;
+        
+        /// <summary>Serial number enabled</summary>
+        public byte SerNumEnable;
+        
+        /// <summary>USB version enabled</summary>
+        public byte USBVersionEnable;
+        
+        /// <summary>USB version (BCD format, e.g., 0x0200 for USB 2.0)</summary>
+        public ushort USBVersion;
+        
+        /// <summary>Channel A high current mode</summary>
+        public byte AIsHighCurrent;
+        
+        /// <summary>Channel A uses VCP driver</summary>
+        public byte AIsVCP;
+        
+        /// <summary>Channel A FIFO mode</summary>
+        public byte AIsFifo;
+        
+        /// <summary>Channel A FIFO target mode</summary>
+        public byte AIsFifoTarget;
+        
+        /// <summary>Channel A fast serial mode</summary>
+        public byte AIsFastSer;
+        
+        /// <summary>Channel A driver type (0=D2XX, 1=VCP)</summary>
+        public byte ADriverType;
+        
+        /// <summary>Channel B high current mode</summary>
+        public byte BIsHighCurrent;
+        
+        /// <summary>Channel B uses VCP driver</summary>
+        public byte BIsVCP;
+        
+        /// <summary>Channel B FIFO mode</summary>
+        public byte BIsFifo;
+        
+        /// <summary>Channel B FIFO target mode</summary>
+        public byte BIsFifoTarget;
+        
+        /// <summary>Channel B fast serial mode</summary>
+        public byte BIsFastSer;
+        
+        /// <summary>Channel B driver type (0=D2XX, 1=VCP)</summary>
+        public byte BDriverType;
+    }
+
+    /// <summary>
+    /// Erases the EEPROM of an FTDI device
+    /// </summary>
+    /// <param name="handle">Device handle from FT_Open</param>
+    public static void EraseEeprom(IntPtr handle)
+    {
+        var status = FT_EraseEE(handle);
+        Native.CheckStatus(status);
+    }
+
+    /// <summary>
+    /// Programs the EEPROM of an FTDI device
+    /// </summary>
+    /// <param name="handle">Device handle from FT_Open</param>
+    /// <param name="eepromData">EEPROM data to program</param>
+    public static void ProgramEeprom(IntPtr handle, ref EepromData eepromData)
+    {
+        // FT232H and FT2232H use different EEPROM programming APIs:
+        // - FT232H: Uses FT_EE_Program with FT_PROGRAM_DATA structure (Version 5)
+        // - FT2232H: Uses FT_EEPROM_Program with FT_EEPROM_2232H structure (Version 3)
+        
+        bool isFt232H = eepromData.ProductId == 0x6014;
+        
+        if (isFt232H)
+        {
+            // FT232H uses FT_EE_Program API with FT_PROGRAM_DATA
+            // IMPORTANT: String fields are char* pointers - must allocate memory
+            var programData = new FT_PROGRAM_DATA();
+            
+            // Allocate string memory
+            IntPtr pManufacturer = Marshal.StringToHGlobalAnsi(eepromData.Manufacturer ?? "");
+            IntPtr pManufacturerId = Marshal.StringToHGlobalAnsi(eepromData.ManufacturerId ?? "");
+            IntPtr pDescription = Marshal.StringToHGlobalAnsi(eepromData.Description ?? "");
+            IntPtr pSerialNumber = Marshal.StringToHGlobalAnsi(eepromData.SerialNumber ?? "");
+            
+            try
+            {
+                // Set structure fields
+                programData.Signature1 = 0x00000000;
+                programData.Signature2 = 0xFFFFFFFF;
+                programData.Version = 5;  // FT232H requires Version 5
+                programData.VendorId = eepromData.VendorId;
+                programData.ProductId = eepromData.ProductId;
+                programData.Manufacturer = pManufacturer;
+                programData.ManufacturerId = pManufacturerId;
+                programData.Description = pDescription;
+                programData.SerialNumber = pSerialNumber;
+                programData.MaxPower = eepromData.MaxPower;
+                programData.PnP = eepromData.PnP;
+                programData.SelfPowered = eepromData.SelfPowered;
+                programData.RemoteWakeup = eepromData.RemoteWakeup;
+                
+                // Version 5 fields (FT232H)
+                programData.Rev5 = 1;  // Indicate FT232H
+                programData.IsoIn = 0;
+                programData.IsoOut = 0;
+                programData.PullDownEnable5 = eepromData.PullDownEnable;
+                programData.SerNumEnable5 = eepromData.SerNumEnable;
+                programData.USBVersionEnable5 = eepromData.USBVersionEnable;
+                programData.USBVersion5 = eepromData.USBVersion;
+                
+                // FT232H specific fields (Rev9 extensions) - set safe defaults
+                programData.PullDownEnableH = eepromData.PullDownEnable;
+                programData.SerNumEnableH = eepromData.SerNumEnable;
+                programData.ACSlowSlewH = 0;
+                programData.ACSchmittInputH = 0;
+                programData.ACDriveCurrentH = 4;  // 4mA
+                programData.ADSlowSlewH = 0;
+                programData.ADSchmittInputH = 0;
+                programData.ADDriveCurrentH = 4;
+                programData.IsVCPH = (byte)(eepromData.ADriverType == 0 ? 1 : 0);  // D2XX=0 wants VCP=0, VCP wants VCP=1
+                programData.PowerSaveEnableH = 0;
+
+                var status = FT_EE_Program(handle, ref programData);
+                Native.CheckStatus(status);
+            }
+            finally
+            {
+                // Free allocated memory
+                Marshal.FreeHGlobal(pManufacturer);
+                Marshal.FreeHGlobal(pManufacturerId);
+                Marshal.FreeHGlobal(pDescription);
+                Marshal.FreeHGlobal(pSerialNumber);
+            }
+        }
+        else
+        {
+            // FT2232H uses FT_EEPROM_Program API with FT_EEPROM_2232H
+            var ft2232hData = new FT_EEPROM_2232H
+            {
+                Common = new FT_EEPROM_HEADER
+                {
+                    DeviceType = 6,  // FT_DEVICE_2232H = 6
+                    VendorId = eepromData.VendorId,
+                    ProductId = eepromData.ProductId,
+                    SerNumEnable = eepromData.SerNumEnable,
+                    MaxPower = eepromData.MaxPower,
+                    SelfPowered = (byte)eepromData.SelfPowered,
+                    RemoteWakeup = (byte)eepromData.RemoteWakeup,
+                    PullDownEnable = eepromData.PullDownEnable
+                },
+                // Drive options - use safe defaults
+                ALSlowSlew = 0,
+                ALSchmittInput = 0,
+                ALDriveCurrent = 4,  // 4mA
+                AHSlowSlew = 0,
+                AHSchmittInput = 0,
+                AHDriveCurrent = 4,
+                BLSlowSlew = 0,
+                BLSchmittInput = 0,
+                BLDriveCurrent = 4,
+                BHSlowSlew = 0,
+                BHSchmittInput = 0,
+                BHDriveCurrent = 4,
+                // Hardware options
+                AIsFifo = eepromData.AIsFifo,
+                AIsFifoTar = eepromData.AIsFifoTarget,
+                AIsFastSer = eepromData.AIsFastSer,
+                BIsFifo = eepromData.BIsFifo,
+                BIsFifoTar = eepromData.BIsFifoTarget,
+                BIsFastSer = eepromData.BIsFastSer,
+                PowerSaveEnable = 0,
+                // Driver type
+                ADriverType = eepromData.ADriverType,
+                BDriverType = eepromData.BDriverType
+            };
+
+            uint eepromSize = (uint)Marshal.SizeOf(ft2232hData);
+            var status = FT_EEPROM_Program(
+                handle,
+                ref ft2232hData,
+                eepromSize,
+                eepromData.Manufacturer,
+                eepromData.ManufacturerId,
+                eepromData.Description,
+                eepromData.SerialNumber);
+
+            Native.CheckStatus(status);
+        }
+    }
+
+    /// <summary>
+    /// Reads the EEPROM of an FTDI device
+    /// </summary>
+    /// <param name="handle">Device handle from FT_Open</param>
+    /// <param name="eepromData">EEPROM data structure to fill</param>
+    public static void ReadEeprom(IntPtr handle, ref EepromData eepromData)
+    {
+        // Per FTDI documentation: String buffers MUST be pre-allocated by the caller
+        // FT_EE_Read fills in these buffers with null-terminated strings
+        
+        // Create byte arrays and pin them
+        byte[] manufacturerBuf = new byte[64];
+        byte[] manufacturerIdBuf = new byte[32];
+        byte[] descriptionBuf = new byte[128];
+        byte[] serialNumberBuf = new byte[32];
+        
+        // Pin the arrays and get pointers
+        var hManufacturer = GCHandle.Alloc(manufacturerBuf, GCHandleType.Pinned);
+        var hManufacturerId = GCHandle.Alloc(manufacturerIdBuf, GCHandleType.Pinned);
+        var hDescription = GCHandle.Alloc(descriptionBuf, GCHandleType.Pinned);
+        var hSerialNumber = GCHandle.Alloc(serialNumberBuf, GCHandleType.Pinned);
+        
+        try
+        {
+            var programData = new FT_PROGRAM_DATA
+            {
+                Signature1 = 0x00000000,
+                Signature2 = 0xFFFFFFFF,
+                Version = 5,  // For FT232H
+                Manufacturer = hManufacturer.AddrOfPinnedObject(),
+                ManufacturerId = hManufacturerId.AddrOfPinnedObject(),
+                Description = hDescription.AddrOfPinnedObject(),
+                SerialNumber = hSerialNumber.AddrOfPinnedObject()
+            };
+
+            var status = FT_EE_Read(handle, ref programData);
+            Native.CheckStatus(status);
+            
+            // Convert buffers to strings
+            eepromData.Signature1 = programData.Signature1;
+            eepromData.Signature2 = programData.Signature2;
+            eepromData.Version = programData.Version;
+            eepromData.VendorId = programData.VendorId;
+            eepromData.ProductId = programData.ProductId;
+            eepromData.Manufacturer = System.Text.Encoding.ASCII.GetString(manufacturerBuf).TrimEnd('\0');
+            eepromData.ManufacturerId = System.Text.Encoding.ASCII.GetString(manufacturerIdBuf).TrimEnd('\0');
+            eepromData.Description = System.Text.Encoding.ASCII.GetString(descriptionBuf).TrimEnd('\0');
+            eepromData.SerialNumber = System.Text.Encoding.ASCII.GetString(serialNumberBuf).TrimEnd('\0');
+            eepromData.MaxPower = programData.MaxPower;
+            eepromData.PnP = programData.PnP;
+            eepromData.SelfPowered = programData.SelfPowered;
+            eepromData.RemoteWakeup = programData.RemoteWakeup;
+            eepromData.PullDownEnable = programData.PullDownEnable5;
+            eepromData.SerNumEnable = programData.SerNumEnable5;
+            eepromData.USBVersionEnable = programData.USBVersionEnable5;
+            eepromData.USBVersion = programData.USBVersion5;
+            eepromData.ADriverType = (byte)(programData.IsVCPH == 0 ? 0 : 1);  // D2XX=0, VCP=1
+        }
+        finally
+        {
+            hManufacturer.Free();
+            hManufacturerId.Free();
+            hDescription.Free();
+            hSerialNumber.Free();
+        }
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Driver/FtdiExpander.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Driver/FtdiExpander.cs
@@ -100,16 +100,16 @@ public abstract partial class FtdiExpander :
                 Description = description,
                 Handle = handle
             },
-            FtDeviceType.Ft2232H => new Ft232h
-            {
-                Index = index,
-                Flags = flags,
-                ID = id,
-                LocID = locid,
-                SerialNumber = serialNumber,
-                Description = description,
-                Handle = handle
-            },
+            FtDeviceType.Ft2232H => new Ft2232H
+        {
+            Index = index,
+            Flags = flags,
+            ID = id,
+            LocID = locid,
+            SerialNumber = serialNumber,
+            Description = description,
+            Handle = handle
+        },
             FtDeviceType.Ft4232H => throw new NotImplementedException(),
             _ => throw new NotSupportedException(),
         };

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Driver/FtdiExpanderCollection.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Driver/FtdiExpanderCollection.cs
@@ -73,6 +73,9 @@ public class FtdiExpanderCollection : IEnumerable<FtdiExpander>
             var serialNumber = Encoding.ASCII.GetString(serialNumberBuffer.ToArray(), 0, serialNumberBuffer.IndexOf((byte)0));
             var description = Encoding.ASCII.GetString(descriptionBuffer.ToArray(), 0, descriptionBuffer.IndexOf((byte)0));
 
+            // Debug output
+            Console.WriteLine($"[DEBUG] FTDI Device {index}: Type={deviceType} ({(int)deviceType}), Desc='{description}', Serial='{serialNumber}'");
+
             _expanders.Add(FtdiExpander.Create(index, flags, deviceType, id, locid, serialNumber, description, handle));
         }
     }

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Driver/Native.Ftd2xx.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Driver/Native.Ftd2xx.cs
@@ -7,26 +7,259 @@ internal static partial class Native
 {
     public class Ftd2xx
     {
-        public enum FtDeviceType
+        // FT_PROGRAM_DATA structure - COMPLETE definition from ftd2xx.h
+        // This structure is version-dependent and huge.
+        [StructLayout(LayoutKind.Sequential)]
+        public struct FT_PROGRAM_DATA
         {
-            Ft232BOrFt245B = 0,
-            Ft8U232AmOrFTtU245Am,
-            Ft8U100Ax,
-            UnknownDevice,
-            Ft2232,
-            Ft232ROrFt245R,
-            Ft2232H,
-            Ft4232H,
-            Ft232H,
-            FtXSeries,
-            Ft4222HMode0or2With2Interfaces,
-            Ft4222HMode1or2With4Interfaces,
-            Ft4222HMode3With1Interface,
-            Ft4222OtpProgrammerBoard,
+            // Header
+            public uint Signature1;         // must be 0x00000000
+            public uint Signature2;         // must be 0xffffffff
+            public uint Version;            // 0=original, 1=FT2232, 2=FT232R, 3=FT2232H, 4=FT4232H, 5=FT232H
+
+            // Common
+            public ushort VendorId;
+            public ushort ProductId;
+            public IntPtr Manufacturer;     // char*
+            public IntPtr ManufacturerId;   // char*
+            public IntPtr Description;      // char*
+            public IntPtr SerialNumber;     // char*
+            public ushort MaxPower;
+            public ushort PnP;
+            public ushort SelfPowered;
+            public ushort RemoteWakeup;
+
+            // Rev4 (FT232B) extensions
+            public byte Rev4;
+            public byte IsoIn;
+            public byte IsoOut;
+            public byte PullDownEnable;
+            public byte SerNumEnable;
+            public byte USBVersionEnable;
+            public ushort USBVersion;
+
+            // Rev5 (FT2232) extensions
+            public byte Rev5;
+            public byte IsoInA;
+            public byte IsoInB;
+            public byte IsoOutA;
+            public byte IsoOutB;
+            public byte PullDownEnable5;
+            public byte SerNumEnable5;
+            public byte USBVersionEnable5;
+            public ushort USBVersion5;
+            public byte AIsHighCurrent;
+            public byte BIsHighCurrent;
+            public byte IFAIsFifo;
+            public byte IFAIsFifoTar;
+            public byte IFAIsFastSer;
+            public byte AIsVCP;
+            public byte IFBIsFifo;
+            public byte IFBIsFifoTar;
+            public byte IFBIsFastSer;
+            public byte BIsVCP;
+
+            // Rev6 (FT232R) extensions
+            public byte UseExtOsc;
+            public byte HighDriveIOs;
+            public byte EndpointSize;
+            public byte PullDownEnableR;
+            public byte SerNumEnableR;
+            public byte InvertTXD;
+            public byte InvertRXD;
+            public byte InvertRTS;
+            public byte InvertCTS;
+            public byte InvertDTR;
+            public byte InvertDSR;
+            public byte InvertDCD;
+            public byte InvertRI;
+            public byte Cbus0;
+            public byte Cbus1;
+            public byte Cbus2;
+            public byte Cbus3;
+            public byte Cbus4;
+            public byte RIsD2XX;
+
+            // Rev7 (FT2232H) extensions
+            public byte PullDownEnable7;
+            public byte SerNumEnable7;
+            public byte ALSlowSlew;
+            public byte ALSchmittInput;
+            public byte ALDriveCurrent;
+            public byte AHSlowSlew;
+            public byte AHSchmittInput;
+            public byte AHDriveCurrent;
+            public byte BLSlowSlew;
+            public byte BLSchmittInput;
+            public byte BLDriveCurrent;
+            public byte BHSlowSlew;
+            public byte BHSchmittInput;
+            public byte BHDriveCurrent;
+            public byte IFAIsFifo7;
+            public byte IFAIsFifoTar7;
+            public byte IFAIsFastSer7;
+            public byte AIsVCP7;
+            public byte IFBIsFifo7;
+            public byte IFBIsFifoTar7;
+            public byte IFBIsFastSer7;
+            public byte BIsVCP7;
+            public byte PowerSaveEnable;
+
+            // Rev8 (FT4232H) extensions
+            public byte PullDownEnable8;
+            public byte SerNumEnable8;
+            public byte ASlowSlew;
+            public byte ASchmittInput;
+            public byte ADriveCurrent;
+            public byte BSlowSlew;
+            public byte BSchmittInput;
+            public byte BDriveCurrent;
+            public byte CSlowSlew;
+            public byte CSchmittInput;
+            public byte CDriveCurrent;
+            public byte DSlowSlew;
+            public byte DSchmittInput;
+            public byte DDriveCurrent;
+            public byte ARIIsTXDEN;
+            public byte BRIIsTXDEN;
+            public byte CRIIsTXDEN;
+            public byte DRIIsTXDEN;
+            public byte AIsVCP8;
+            public byte BIsVCP8;
+            public byte CIsVCP8;
+            public byte DIsVCP8;
+
+            // Rev9 (FT232H) extensions
+            public byte PullDownEnableH;
+            public byte SerNumEnableH;
+            public byte ACSlowSlewH;
+            public byte ACSchmittInputH;
+            public byte ACDriveCurrentH;
+            public byte ADSlowSlewH;
+            public byte ADSchmittInputH;
+            public byte ADDriveCurrentH;
+            public byte Cbus0H;
+            public byte Cbus1H;
+            public byte Cbus2H;
+            public byte Cbus3H;
+            public byte Cbus4H;
+            public byte Cbus5H;
+            public byte Cbus6H;
+            public byte Cbus7H;
+            public byte Cbus8H;
+            public byte Cbus9H;
+            public byte IsFifoH;
+            public byte IsFifoTarH;
+            public byte IsFastSerH;
+            public byte IsFT1248H;
+            public byte FT1248CpolH;
+            public byte FT1248LsbH;
+            public byte FT1248FlowControlH;
+            public byte IsVCPH;
+            public byte PowerSaveEnableH;
+        }
+
+        // EEPROM structure for FT232H (single-channel)
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        public struct FT_EEPROM_232H
+        {
+            public uint Signature1;          // Header - must be 0x00000000
+            public uint Signature2;          // Header - must be 0xFFFFFFFF
+            public uint Version;             // Header - must be 5 for FT232H
+            public ushort VendorId;          // 0x0403
+            public ushort ProductId;         // 0x6014
+            
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+            public string Manufacturer;
+            
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 16)]
+            public string ManufacturerId;
+            
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
+            public string Description;
+            
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 16)]
+            public string SerialNumber;
+            
+            public ushort MaxPower;          // Max power consumption in mA
+            public ushort PnP;               // 0 = disabled, 1 = enabled
+            public ushort SelfPowered;       // 0 = bus powered, 1 = self powered
+            public ushort RemoteWakeup;      // 0 = not capable, 1 = capable
+            
+            // FT232H specific
+            public byte PullDownEnable;      // non-zero if pull down enabled
+            public byte SerNumEnable;        // non-zero if serial number to be used
+            public byte USBVersionEnable;    // non-zero if chip uses USBVersion
+            public ushort USBVersion;        // BCD (0x0200 => USB2)
+            
+            // Channel A Config (FT232H only has one channel)
+            public byte AIsHighCurrent;      // non-zero if interface is high current
+            public byte AIsFifo;             // non-zero if interface is to use FIFO mode
+            public byte AIsFifoTarget;       // non-zero if interface is to use FIFO target mode
+            public byte AIsFastSer;          // non-zero if interface is to use fast serial mode
+            public byte ADriverType;         // Driver type (0=D2XX, 1=VCP)
+            
+            // FT232H specific features
+            public byte PowerSaveEnable;     // non-zero if power save enabled
+            public byte ClockPolarityActive; // 0 = active high, 1 = active low
+            public byte FlowControl;         // 0 = disabled, 1 = RTS/CTS, 2 = DTR/DSR, 3 = XON/XOFF
+            public byte IsVCP;               // non-zero if using VCP driver
+            public byte PowerSaveEnable2;    // Additional power save setting
+        }
+
+        // FT_EEPROM_HEADER - common header for FT_EEPROM_* structures
+        [StructLayout(LayoutKind.Sequential)]
+        public struct FT_EEPROM_HEADER
+        {
+            public uint DeviceType;         // FT_DEVICE - FTxxxx device type to be programmed
+            public ushort VendorId;         // 0x0403
+            public ushort ProductId;        // Device-specific
+            public byte SerNumEnable;       // non-zero if serial number to be used
+            public ushort MaxPower;         // 0 < MaxPower <= 500
+            public byte SelfPowered;        // 0 = bus powered, 1 = self powered
+            public byte RemoteWakeup;       // 0 = not capable, 1 = capable
+            public byte PullDownEnable;     // non-zero if pull down in suspend enabled
+        }
+
+        // FT_EEPROM_2232H structure for use with FT_EEPROM_Read and FT_EEPROM_Program
+        // Matches FTDI ftd2xx.h exactly
+        [StructLayout(LayoutKind.Sequential)]
+        public struct FT_EEPROM_2232H
+        {
+            // Common header
+            public FT_EEPROM_HEADER Common;
+            
+            // Drive options
+            public byte ALSlowSlew;         // non-zero if AL pins have slow slew
+            public byte ALSchmittInput;     // non-zero if AL pins are Schmitt input
+            public byte ALDriveCurrent;     // valid values are 4, 8, 12, 16 (mA)
+            public byte AHSlowSlew;         // non-zero if AH pins have slow slew
+            public byte AHSchmittInput;     // non-zero if AH pins are Schmitt input
+            public byte AHDriveCurrent;     // valid values are 4, 8, 12, 16 (mA)
+            public byte BLSlowSlew;         // non-zero if BL pins have slow slew
+            public byte BLSchmittInput;     // non-zero if BL pins are Schmitt input
+            public byte BLDriveCurrent;     // valid values are 4, 8, 12, 16 (mA)
+            public byte BHSlowSlew;         // non-zero if BH pins have slow slew
+            public byte BHSchmittInput;     // non-zero if BH pins are Schmitt input
+            public byte BHDriveCurrent;     // valid values are 4, 8, 12, 16 (mA)
+            
+            // Hardware options
+            public byte AIsFifo;            // non-zero if interface is 245 FIFO
+            public byte AIsFifoTar;         // non-zero if interface is 245 FIFO CPU target
+            public byte AIsFastSer;         // non-zero if interface is Fast serial
+            public byte BIsFifo;            // non-zero if interface is 245 FIFO
+            public byte BIsFifoTar;         // non-zero if interface is 245 FIFO CPU target
+            public byte BIsFastSer;         // non-zero if interface is Fast serial
+            public byte PowerSaveEnable;    // non-zero if using BCBUS7 to save power
+            
+            // Driver option
+            public byte ADriverType;        // 0 = D2XX, 1 = VCP
+            public byte BDriverType;        // 0 = D2XX, 1 = VCP
         }
 
         private const string FTDI_LIB = "ftd2xx";
 
+        // Existing functions...
         [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public static extern FT_STATUS FT_CreateDeviceInfoList(out uint numdevs);
 
@@ -80,5 +313,82 @@ internal static partial class Native
 
         [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public static extern FT_STATUS FT_GetLibraryVersion(out uint lpdwVersion);
+
+        // EEPROM Programming Functions for FT232H
+        [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public static extern FT_STATUS FT_EEPROM_Read(IntPtr ftHandle, ref FT_EEPROM_232H eepromData, uint eepromDataSize, 
+            [MarshalAs(UnmanagedType.LPStr)] string manufacturer, 
+            [MarshalAs(UnmanagedType.LPStr)] string manufacturerId,
+            [MarshalAs(UnmanagedType.LPStr)] string description,
+            [MarshalAs(UnmanagedType.LPStr)] string serialNumber);
+
+        [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public static extern FT_STATUS FT_EEPROM_Program(IntPtr ftHandle, ref FT_EEPROM_232H eepromData, uint eepromDataSize,
+            [MarshalAs(UnmanagedType.LPStr)] string manufacturer,
+            [MarshalAs(UnmanagedType.LPStr)] string manufacturerId,
+            [MarshalAs(UnmanagedType.LPStr)] string description,
+            [MarshalAs(UnmanagedType.LPStr)] string serialNumber);
+
+        // EEPROM Programming Functions for FT2232H
+        [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public static extern FT_STATUS FT_EEPROM_Read(IntPtr ftHandle, ref FT_EEPROM_2232H eepromData, uint eepromDataSize, 
+            [MarshalAs(UnmanagedType.LPStr)] string manufacturer, 
+            [MarshalAs(UnmanagedType.LPStr)] string manufacturerId,
+            [MarshalAs(UnmanagedType.LPStr)] string description,
+            [MarshalAs(UnmanagedType.LPStr)] string serialNumber);
+
+        [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public static extern FT_STATUS FT_EEPROM_Program(IntPtr ftHandle, ref FT_EEPROM_2232H eepromData, uint eepromDataSize,
+            [MarshalAs(UnmanagedType.LPStr)] string manufacturer,
+            [MarshalAs(UnmanagedType.LPStr)] string manufacturerId,
+            [MarshalAs(UnmanagedType.LPStr)] string description,
+            [MarshalAs(UnmanagedType.LPStr)] string serialNumber);
+
+        // FT_EE_Program/FT_EE_Read - Older API using FT_PROGRAM_DATA (for FT232H)
+        [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public static extern FT_STATUS FT_EE_Program(IntPtr ftHandle, ref FT_PROGRAM_DATA programData);
+
+        [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public static extern FT_STATUS FT_EE_Read(IntPtr ftHandle, ref FT_PROGRAM_DATA programData);
+
+        [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public static extern FT_STATUS FT_EraseEE(IntPtr ftHandle);
+
+        // Recovery/Advanced functions
+        [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public static extern FT_STATUS FT_ResetDevice(IntPtr ftHandle);
+
+        [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public static extern FT_STATUS FT_CyclePort(IntPtr ftHandle);
+
+        // FT_OpenEx - can open by serial number, description, or location
+        [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true, CharSet = CharSet.Ansi)]
+        public static extern FT_STATUS FT_OpenEx(string pvArg1, uint dwFlags, out IntPtr ftHandle);
+
+        [DllImport(FTDI_LIB, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public static extern FT_STATUS FT_OpenEx(uint pvArg1, uint dwFlags, out IntPtr ftHandle);
+
+        // FT_OpenEx flags
+        public const uint FT_OPEN_BY_SERIAL_NUMBER = 1;
+        public const uint FT_OPEN_BY_DESCRIPTION = 2;
+        public const uint FT_OPEN_BY_LOCATION = 4;
+
+        public enum FtDeviceType
+        {
+            Ft232BOrFt245B = 0,
+            Ft8U232AmOrFTtU245Am,
+            Ft8U100Ax,
+            UnknownDevice,
+            Ft2232,
+            Ft232ROrFt245R,
+            Ft2232H,
+            Ft4232H,
+            Ft232H,
+            FtXSeries,
+            Ft4222HMode0or2With2Interfaces,
+            Ft4222HMode1or2With4Interfaces,
+            Ft4222HMode3With1Interface,
+            Ft4222OtpProgrammerBoard,
+        }
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/Ft2232h_Sample/Ft2232h_Sample.csproj
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/Ft2232h_Sample/Ft2232h_Sample.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Company>Wilderness Labs, Inc</Company>
+    <Authors>Wilderness Labs, Inc</Authors>
+    <LangVersion>12.0</LangVersion>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<ProjectReference Include="..\..\..\..\Meadow.Foundation.Libraries_and_Frameworks\Graphics.MicroGraphics\Driver\Graphics.MicroGraphics.csproj" />
+	<ProjectReference Include="..\..\..\Displays.TftSpi\Driver\Displays.TftSpi.csproj" />
+    <ProjectReference Include="..\..\..\ICs.ADC.Mcp3xxx\Driver\ICs.ADC.Mcp3xxx.csproj" />
+    <ProjectReference Include="..\..\..\Sensors.Light.Veml7700\Driver\Sensors.Light.Veml7700.csproj" />
+    <ProjectReference Include="..\..\..\Sensors.Atmospheric.Bme68x\Driver\Sensors.Atmospheric.Bme68x.csproj" />
+    <ProjectReference Include="..\..\Driver\ICs.IOExpanders.Ftxxxx.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/Ft2232h_Sample/Program.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/Ft2232h_Sample/Program.cs
@@ -1,0 +1,247 @@
+﻿// FT2232H Sample Application
+using Meadow;
+using Meadow.Foundation.Displays;
+using Meadow.Foundation.Graphics;
+using Meadow.Foundation.ICs.ADC;
+using Meadow.Foundation.ICs.IOExpanders;
+using Meadow.Foundation.Sensors.Atmospheric;
+using Meadow.Foundation.Sensors.Light;
+using Meadow.Hardware;
+using Meadow.Peripherals.Displays;
+using System.Diagnostics;
+
+Console.WriteLine("HELLO FROM THE WILDERNESS FT2232H DRIVER!");
+Console.WriteLine("Testing BME688 Environmental Sensor over I2C");
+
+FtdiExpander? expander = null;
+
+// Make sure we clean up resources when the program is terminated
+Console.CancelKeyPress += (s, e) =>
+{
+    Console.WriteLine("\nCleaning up...");
+    expander?.Dispose();
+    e.Cancel = false; // Allow the process to terminate
+};
+
+// Main logic.
+try 
+{
+    var count = FtdiExpanderCollection.Devices.Count;
+    Console.WriteLine($"Found {count} FTDI devices");
+
+    if (count == 0)
+    {
+        Console.WriteLine("No devices found.");
+        return;
+    }
+
+    // List all available devices
+    Console.WriteLine("\nAvailable devices:");
+    foreach (var device in FtdiExpanderCollection.Devices)
+    {
+        Console.WriteLine($"  - {device.GetType().Name}: {device.Description} (Serial: {device.SerialNumber})");
+    }
+
+    // NOTE: The FT2232H EEPROM appears to be unprogrammed (detected as Ft232BOrFt245B type 0)
+    // This means it won't enumerate as two separate channels with proper descriptions.
+    // For now, we'll use whatever device was detected and try to communicate with I2C.
+    
+    if (FtdiExpanderCollection.Devices.Count == 0)
+    {
+        Console.WriteLine("\n[!] No FTDI devices found.");
+        return;
+    }
+
+    expander = FtdiExpanderCollection.Devices[0];
+    
+    Console.WriteLine($"\nUsing device: {expander.GetType().Name}");
+    Console.WriteLine($"Description: '{expander.Description}'");
+    Console.WriteLine($"Serial Number: '{expander.SerialNumber}'");
+    Console.WriteLine("\n[!] WARNING: Device EEPROM appears unprogrammed (Type=Ft232BOrFt245B)");
+    Console.WriteLine("    The FT2232H should enumerate as 'Ft2232H' with channel descriptions.");
+    Console.WriteLine("    Attempting I2C communication anyway...\n");
+
+    // Test BME688 over I2C
+    // Note: We don't know which channel this will use without proper EEPROM programming
+    await TestBME688(expander);
+}
+catch (Exception ex)
+{
+    if (ex.Message.Contains("FT_DEVICE_NOT_OPENED"))
+    {
+        Console.WriteLine("\n[!] CRITICAL ERROR: The device handle is stuck in an OPEN state.");
+        Console.WriteLine("    This usually happens if the application was terminated abruptly.");
+        Console.WriteLine("    ACTION REQUIRED: Unplug the USB device and plug it back in to reset the driver.\n");
+    }
+    else
+    {
+        Console.WriteLine($"An error occurred: {ex.Message}");
+        Console.WriteLine(ex.StackTrace);
+    }
+}
+finally
+{
+    Console.WriteLine("Cleaning up...");
+    expander?.Dispose();
+}
+
+async Task TestSPIDisplay(FtdiExpander expander)
+{
+    Console.WriteLine("Testing SPI with display...");
+    var display = new St7789
+        (
+            spiBus: expander.CreateSpiBus(),
+            chipSelectPin: expander.Pins.D0,
+            dcPin: expander.Pins.D1,
+            resetPin: null,
+            135, 240
+        );
+
+    var microGraphics = new MicroGraphics(display)
+    {
+        CurrentFont = new Font12x16(),
+        Rotation = RotationType._270Degrees
+    };
+
+    microGraphics.Clear();
+    microGraphics.DrawText(0, 0, "FT2232H Test");
+    microGraphics.Show();
+
+    Console.WriteLine("Display initialized. Entering loop...");
+
+    while (true)
+    {
+        Console.WriteLine("Sleeping...");
+        await Task.Delay(1000);
+    }
+}
+
+async Task TestSPI(FtdiExpander expander)
+{
+    Console.WriteLine("Testing SPI with MCP3201...");
+    var mcp = new Mcp3201(
+        expander.CreateSpiBus(),
+        expander.Pins.C1.CreateDigitalOutputPort());
+
+    var inp = mcp.CreateAnalogInputPort();
+
+    while (true)
+    {
+        Debug.WriteLine("Reading...");
+        try
+        {
+            var t = await inp.Read();
+            Debug.WriteLine($"{t.Volts} V");
+        }
+        catch
+        {
+        }
+
+        await Task.Delay(1000);
+    }
+}
+
+async Task TestBME688(FtdiExpander expander)
+{
+    Console.WriteLine("\n=== Testing BME688 Environmental Sensor ===");
+    Console.WriteLine("Initializing I2C bus...");
+    
+    try
+    {
+        var i2cBus = expander.CreateI2cBus();
+        Console.WriteLine("I2C bus created successfully");
+        
+        Console.WriteLine("Initializing BME688 sensor...");
+        var sensor = new Bme688(i2cBus);
+        
+        Console.WriteLine("BME688 initialized successfully!");
+        Console.WriteLine("\nReading environmental data...\n");
+
+        while (true)
+        {
+            try
+            {
+                var conditions = await sensor.Read();
+                
+                Console.WriteLine($"Temperature: {conditions.Temperature?.Celsius:F2}°C");
+                Console.WriteLine($"Pressure: {conditions.Pressure?.Millibar:F2} mbar");
+                Console.WriteLine($"Humidity: {conditions.Humidity?.Percent:F1}%");
+                
+                if (conditions.GasResistance.HasValue)
+                {
+                    Console.WriteLine($"Gas Resistance: {conditions.GasResistance.Value.Ohms:F0} Ω");
+                }
+                
+                Console.WriteLine("---");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error reading sensor: {ex.Message}");
+            }
+
+            await Task.Delay(2000);
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Failed to initialize BME688: {ex.Message}");
+        Console.WriteLine($"Stack trace: {ex.StackTrace}");
+    }
+}
+
+async Task TestI2C(FtdiExpander expander)
+{
+    Console.WriteLine("Initializing I2C sensor (VEML7700)...");
+    var sensor = new Veml7700(expander.CreateI2cBus());
+
+    while (true)
+    {
+        Console.WriteLine("Reading...");
+        try
+        {
+            var t = await sensor.Read();
+            Console.WriteLine($"{t.Lux} lux");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error reading sensor: {ex.Message}");
+        }
+
+        await Task.Delay(1000);
+    }
+}
+
+async Task TestGpio(FtdiExpander expander)
+{
+    Console.WriteLine("Testing GPIO...");
+    var outputs = new List<IDigitalOutputPort>
+    {
+        expander.CreateDigitalOutputPort(expander.Pins.C0),
+        expander.CreateDigitalOutputPort(expander.Pins.C1),
+        expander.CreateDigitalOutputPort(expander.Pins.C2),
+        expander.CreateDigitalOutputPort(expander.Pins.C3),
+        expander.CreateDigitalOutputPort(expander.Pins.C4),
+        expander.CreateDigitalOutputPort(expander.Pins.C5),
+        expander.CreateDigitalOutputPort(expander.Pins.C6),
+        expander.CreateDigitalOutputPort(expander.Pins.C7),
+        expander.CreateDigitalOutputPort(expander.Pins.D3),
+        expander.CreateDigitalOutputPort(expander.Pins.D4),
+        expander.CreateDigitalOutputPort(expander.Pins.D5),
+        expander.CreateDigitalOutputPort(expander.Pins.D6),
+        expander.CreateDigitalOutputPort(expander.Pins.D7)
+    };
+
+    var s = false;
+
+    while (true)
+    {
+        for (var i = 0; i < outputs.Count; i++)
+        {
+            var setTo = (i % 2 == 0) ? s : !s;
+            outputs[i].State = setTo;
+        }
+
+        await Task.Delay(1000);
+        s = !s;
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/DeviceInfo.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/DeviceInfo.cs
@@ -1,0 +1,95 @@
+using Meadow.Foundation.ICs.IOExpanders;
+
+namespace FtxEepromProgrammer;
+
+/// <summary>
+/// Device information display utilities
+/// </summary>
+internal static class DeviceInfo
+{
+    /// <summary>
+    /// Displays detailed information about all connected FTDI devices
+    /// </summary>
+    public static void DisplayDevices()
+    {
+        var count = FtdiExpanderCollection.Devices.Count;
+        
+        if (count == 0)
+        {
+            Console.WriteLine("No FTDI devices found.");
+            return;
+        }
+
+        Console.WriteLine($"Found {count} FTDI device(s):\n");
+
+        for (int i = 0; i < count; i++)
+        {
+            var device = FtdiExpanderCollection.Devices[i];
+            DisplayDeviceSummary(i, device);
+        }
+    }
+
+    /// <summary>
+    /// Displays a summary of a single device
+    /// </summary>
+    private static void DisplayDeviceSummary(int index, FtdiExpander device)
+    {
+        Console.WriteLine($"═══════════════════════════════════════════════════════");
+        Console.WriteLine($"Device [{index}]");
+        Console.WriteLine($"═══════════════════════════════════════════════════════");
+        Console.WriteLine($"  Type:        {device.GetType().Name}");
+        Console.WriteLine($"  Description: {device.Description}");
+        Console.WriteLine($"  Serial:      {device.SerialNumber}");
+        Console.WriteLine();
+    }
+
+    /// <summary>
+    /// Displays detailed EEPROM information for a specific device
+    /// </summary>
+    public static void DisplayEepromInfo(IntPtr handle)
+    {
+        try
+        {
+            Console.WriteLine("═══════════════════════════════════════════════════════");
+            Console.WriteLine("EEPROM Information");
+            Console.WriteLine("═══════════════════════════════════════════════════════");
+
+            var eepromData = new FtdiEeprom.EepromData();
+            FtdiEeprom.ReadEeprom(handle, ref eepromData);
+
+            Console.WriteLine($"  Vendor ID:        0x{eepromData.VendorId:X4}");
+            Console.WriteLine($"  Product ID:       0x{eepromData.ProductId:X4}");
+            Console.WriteLine($"  Manufacturer:     {eepromData.Manufacturer}");
+            Console.WriteLine($"  Manufacturer ID:  {eepromData.ManufacturerId}");
+            Console.WriteLine($"  Description:      {eepromData.Description}");
+            Console.WriteLine($"  Serial Number:    {eepromData.SerialNumber}");
+            Console.WriteLine($"  Max Power:        {eepromData.MaxPower}mA");
+            Console.WriteLine($"  USB Version:      0x{eepromData.USBVersion:X4}");
+            Console.WriteLine($"  Self Powered:     {(eepromData.SelfPowered != 0 ? "Yes" : "No")}");
+            Console.WriteLine($"  Remote Wakeup:    {(eepromData.RemoteWakeup != 0 ? "Yes" : "No")}");
+            Console.WriteLine();
+            Console.WriteLine("  Channel A:");
+            Console.WriteLine($"    Driver Type:    {(eepromData.ADriverType == 0 ? "D2XX" : "VCP")}");
+            Console.WriteLine($"    High Current:   {(eepromData.AIsHighCurrent != 0 ? "Yes" : "No")}");
+            Console.WriteLine($"    FIFO Mode:      {(eepromData.AIsFifo != 0 ? "Yes" : "No")}");
+            Console.WriteLine();
+            
+            // Only show Channel B for dual-channel devices (FT2232H = 0x6010)
+            bool isDualChannel = eepromData.ProductId == 0x6010;
+            if (isDualChannel)
+            {
+                Console.WriteLine("  Channel B:");
+                Console.WriteLine($"    Driver Type:    {(eepromData.BDriverType == 0 ? "D2XX" : "VCP")}");
+                Console.WriteLine($"    High Current:   {(eepromData.BIsHighCurrent != 0 ? "Yes" : "No")}");
+                Console.WriteLine($"    FIFO Mode:      {(eepromData.BIsFifo != 0 ? "Yes" : "No")}");
+                Console.WriteLine();
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[ERROR] Failed to read EEPROM: {ex.Message}");
+            Console.WriteLine("(This may be normal if the EEPROM is blank or corrupted)");
+            Console.WriteLine();
+        }
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/DiagnosticTests.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/DiagnosticTests.cs
@@ -1,0 +1,52 @@
+using Meadow.Foundation.ICs.IOExpanders;
+
+namespace FtxEepromProgrammer;
+
+/// <summary>
+/// Diagnostic tools to test FTDI EEPROM API
+/// </summary>
+internal static class DiagnosticTests
+{
+    public static void TestFtEeRead()
+    {
+        Console.WriteLine("═══════════════════════════════════════════════════════");
+        Console.WriteLine("DIAGNOSTIC TEST - FT_EE_Read");
+        Console.WriteLine("═══════════════════════════════════════════════════════\n");
+        Console.WriteLine("This will test if FT_EE_Read works on macOS.");
+        Console.WriteLine("If it works, we know the structure is correct.");
+        Console.WriteLine("If it crashes, the API isn't available on macOS.\n");
+
+        try
+        {
+            // Open device
+            Console.Write("Opening device at index 0... ");
+            var handle = FtdiEeprom.OpenDevice(0);
+            Console.WriteLine("✓ Opened");
+
+            Console.Write("Calling FT_EE_Read... ");
+            var (success, error, version, vid, pid) = FtdiEeprom.TestFtEeRead(handle);
+            
+            if (success)
+            {
+                Console.WriteLine("✓ SUCCESS!");
+                Console.WriteLine("\nRead EEPROM data:");
+                Console.WriteLine($"  Version: {version}");
+                Console.WriteLine($"  VID: 0x{vid:X4}");
+                Console.WriteLine($"  PID: 0x{pid:X4}");
+            }
+            else
+            {
+                Console.WriteLine($"✗ Failed: {error}");
+            }
+
+            FtdiEeprom.CloseDevice(handle);
+            Console.WriteLine("\n✓ Device closed successfully");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"\n✗ CRASHED: {ex.Message}");
+            Console.WriteLine($"Type: {ex.GetType().Name}");
+            Console.WriteLine("\nThis means FT_EE_Read is not working on macOS.");
+        }
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/EepromConfig.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/EepromConfig.cs
@@ -1,0 +1,38 @@
+namespace FtxEepromProgrammer;
+
+/// <summary>
+/// EEPROM configuration model
+/// </summary>
+internal class EepromConfig
+{
+    public string? DeviceType { get; set; }
+    public string? VendorId { get; set; }
+    public string? ProductId { get; set; }
+    public string? Manufacturer { get; set; }
+    public string? ManufacturerId { get; set; }
+    public string? Description { get; set; }
+    public string? SerialNumber { get; set; }
+    public ushort MaxPower { get; set; }
+    public bool PnP { get; set; }
+    public bool SelfPowered { get; set; }
+    public bool RemoteWakeup { get; set; }
+    public bool PullDownEnable { get; set; }
+    public bool SerNumEnable { get; set; }
+    public bool UsbVersionEnable { get; set; }
+    public string? UsbVersion { get; set; }
+    public ChannelConfig? ChannelA { get; set; }
+    public ChannelConfig? ChannelB { get; set; }
+}
+
+/// <summary>
+/// Channel-specific configuration
+/// </summary>
+internal class ChannelConfig
+{
+    public bool IsHighCurrent { get; set; }
+    public bool IsVCP { get; set; }
+    public bool IsFifo { get; set; }
+    public bool IsFifoTarget { get; set; }
+    public bool IsFastSer { get; set; }
+    public string? DriverType { get; set; }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/EepromOperations.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/EepromOperations.cs
@@ -132,10 +132,40 @@ internal static class EepromOperations
             Console.WriteLine("⚠ WARNING: SerialNumber is empty");
         }
 
+        // Validate string lengths per FTDI requirements
+        const int MaxManufacturer = 31;      // 32 bytes including null terminator
+        const int MaxManufacturerId = 15;    // 16 bytes including null terminator  
+        const int MaxDescription = 31;       // 32 bytes including null terminator
+        const int MaxSerialNumber = 15;      // 16 bytes including null terminator
+
+        if ((config.Manufacturer?.Length ?? 0) > MaxManufacturer)
+        {
+            Console.WriteLine($"✗ ERROR: Manufacturer too long ({config.Manufacturer!.Length} chars, max {MaxManufacturer})");
+            hasErrors = true;
+        }
+        
+        if ((config.ManufacturerId?.Length ?? 0) > MaxManufacturerId)
+        {
+            Console.WriteLine($"✗ ERROR: ManufacturerId too long ({config.ManufacturerId!.Length} chars, max {MaxManufacturerId})");
+            hasErrors = true;
+        }
+        
+        if ((config.Description?.Length ?? 0) > MaxDescription)
+        {
+            Console.WriteLine($"✗ ERROR: Description too long ({config.Description!.Length} chars, max {MaxDescription})");
+            hasErrors = true;
+        }
+        
+        if ((config.SerialNumber?.Length ?? 0) > MaxSerialNumber)
+        {
+            Console.WriteLine($"✗ ERROR: SerialNumber too long ({config.SerialNumber!.Length} chars, max {MaxSerialNumber})");
+            hasErrors = true;
+        }
+
         if (hasErrors)
         {
-            Console.WriteLine("\n[CRITICAL ERROR] Configuration has missing critical fields!");
-            Console.WriteLine("Programming with empty VID/PID will BRICK the device!");
+            Console.WriteLine("\n[CRITICAL ERROR] Configuration has validation errors!");
+            Console.WriteLine("Programming with invalid fields may BRICK the device!");
             Console.WriteLine("Please fix the configuration file and try again.\n");
             return;
         }

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/EepromOperations.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/EepromOperations.cs
@@ -1,0 +1,209 @@
+using Meadow.Foundation.ICs.IOExpanders;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace FtxEepromProgrammer;
+
+/// <summary>
+/// EEPROM programming and erasing operations
+/// </summary>
+internal static class EepromOperations
+{
+    /// <summary>
+    /// Erases the EEPROM, restoring device to factory defaults
+    /// </summary>
+    public static void EraseEeprom(IntPtr handle)
+    {
+        Console.WriteLine("═══════════════════════════════════════════════════════");
+        Console.WriteLine("ERASING EEPROM");
+        Console.WriteLine("═══════════════════════════════════════════════════════\n");
+        Console.WriteLine("This will erase the EEPROM and restore the device to");
+        Console.WriteLine("factory defaults (blank EEPROM state).");
+        Console.Write("\nAre you sure? [y/N]: ");
+        var confirm = Console.ReadLine();
+        if (confirm?.ToLower() != "y")
+        {
+            Console.WriteLine("Cancelled.");
+            return;
+        }
+
+        Console.WriteLine("\nErasing EEPROM...");
+        
+        try
+        {
+            FtdiEeprom.EraseEeprom(handle);
+            Console.WriteLine("✓ EEPROM erased successfully!");
+            Console.WriteLine();
+            Console.WriteLine("═══════════════════════════════════════════════════════");
+            Console.WriteLine("IMPORTANT: Unplug and replug the USB cable now!");
+            Console.WriteLine("═══════════════════════════════════════════════════════");
+            Console.WriteLine();
+            Console.WriteLine("The device will now use factory default settings.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[ERROR] EEPROM erase failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Programs EEPROM from a JSON configuration file
+    /// </summary>
+    public static void ProgramFromConfig(IntPtr handle)
+    {
+        Console.WriteLine("═══════════════════════════════════════════════════════");
+        Console.WriteLine("PROGRAM FROM CONFIG FILE");
+        Console.WriteLine("═══════════════════════════════════════════════════════\n");
+
+        // List available configs
+        var configDir = Path.Combine(AppContext.BaseDirectory, "configs");
+        if (!Directory.Exists(configDir))
+        {
+            Console.WriteLine($"Config directory not found: {configDir}");
+            return;
+        }
+
+        var configs = Directory.GetFiles(configDir, "*.json");
+        if (configs.Length == 0)
+        {
+            Console.WriteLine("No config files found.");
+            return;
+        }
+
+        Console.WriteLine("Available configurations:");
+        for (int i = 0; i < configs.Length; i++)
+        {
+            Console.WriteLine($"  [{i}] {Path.GetFileNameWithoutExtension(configs[i])}");
+        }
+
+        Console.Write($"\nSelect config [0]: ");
+        var input = Console.ReadLine();
+        var configIndex = string.IsNullOrWhiteSpace(input) ? 0 : int.Parse(input);
+
+        if (configIndex < 0 || configIndex >= configs.Length)
+        {
+            Console.WriteLine("Invalid config index.");
+            return;
+        }
+
+        // Load and parse config
+        var configPath = configs[configIndex];
+        Console.WriteLine($"\nLoading config: {Path.GetFileName(configPath)}");
+        var json = File.ReadAllText(configPath);
+        
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+        var config = JsonSerializer.Deserialize<EepromConfig>(json, options);
+
+        if (config == null)
+        {
+            Console.WriteLine("Failed to parse config file.");
+            return;
+        }
+
+        // Validate critical fields
+        Console.WriteLine("\n═══════════════════════════════════════════════════════");
+        Console.WriteLine("VALIDATING CONFIGURATION");
+        Console.WriteLine("═══════════════════════════════════════════════════════");
+        
+        bool hasErrors = false;
+        
+        if (string.IsNullOrWhiteSpace(config.VendorId))
+        {
+            Console.WriteLine("✗ ERROR: VendorId is missing or empty!");
+            hasErrors = true;
+        }
+        
+        if (string.IsNullOrWhiteSpace(config.ProductId))
+        {
+            Console.WriteLine("✗ ERROR: ProductId is missing or empty!");
+            hasErrors = true;
+        }
+        
+        if (string.IsNullOrWhiteSpace(config.Description))
+        {
+            Console.WriteLine("⚠ WARNING: Description is empty");
+        }
+        
+        if (string.IsNullOrWhiteSpace(config.SerialNumber))
+        {
+            Console.WriteLine("⚠ WARNING: SerialNumber is empty");
+        }
+
+        if (hasErrors)
+        {
+            Console.WriteLine("\n[CRITICAL ERROR] Configuration has missing critical fields!");
+            Console.WriteLine("Programming with empty VID/PID will BRICK the device!");
+            Console.WriteLine("Please fix the configuration file and try again.\n");
+            return;
+        }
+        
+        Console.WriteLine("✓ Configuration validated successfully\n");
+
+        // Create EEPROM data structure
+        var eepromData = new FtdiEeprom.EepromData
+        {
+            Signature1 = 0x00000000,
+            Signature2 = 0xFFFFFFFF,
+            Version = 3,
+            VendorId = Convert.ToUInt16(config.VendorId, 16),
+            ProductId = Convert.ToUInt16(config.ProductId, 16),
+            Manufacturer = config.Manufacturer ?? "",
+            ManufacturerId = config.ManufacturerId ?? "",
+            Description = config.Description ?? "",
+            SerialNumber = config.SerialNumber ?? "",
+            MaxPower = config.MaxPower,
+            PnP = (ushort)(config.PnP ? 1 : 0),
+            SelfPowered = (ushort)(config.SelfPowered ? 1 : 0),
+            RemoteWakeup = (ushort)(config.RemoteWakeup ? 1 : 0),
+            PullDownEnable = (byte)(config.PullDownEnable ? 1 : 0),
+            SerNumEnable = (byte)(config.SerNumEnable ? 1 : 0),
+            USBVersionEnable = (byte)(config.UsbVersionEnable ? 1 : 0),
+            USBVersion = Convert.ToUInt16(config.UsbVersion, 16),
+            AIsHighCurrent = (byte)(config.ChannelA?.IsHighCurrent == true ? 1 : 0),
+            AIsVCP = (byte)(config.ChannelA?.IsVCP == true ? 1 : 0),
+            AIsFifo = (byte)(config.ChannelA?.IsFifo == true ? 1 : 0),
+            AIsFifoTarget = (byte)(config.ChannelA?.IsFifoTarget == true ? 1 : 0),
+            AIsFastSer = (byte)(config.ChannelA?.IsFastSer == true ? 1 : 0),
+            ADriverType = (byte)(config.ChannelA?.DriverType == "VCP" ? 1 : 0),
+            BIsHighCurrent = (byte)(config.ChannelB?.IsHighCurrent == true ? 1 : 0),
+            BIsVCP = (byte)(config.ChannelB?.IsVCP == true ? 1 : 0),
+            BIsFifo = (byte)(config.ChannelB?.IsFifo == true ? 1 : 0),
+            BIsFifoTarget = (byte)(config.ChannelB?.IsFifoTarget == true ? 1 : 0),
+            BIsFastSer = (byte)(config.ChannelB?.IsFastSer == true ? 1 : 0),
+            BDriverType = (byte)(config.ChannelB?.DriverType == "VCP" ? 1 : 0)
+        };
+
+        Console.WriteLine("Programming EEPROM with:");
+        Console.WriteLine($"  Device Type: {config.DeviceType}");
+        Console.WriteLine($"  Vendor ID: {config.VendorId}");
+        Console.WriteLine($"  Product ID: {config.ProductId}");
+        Console.WriteLine($"  Manufacturer: {config.Manufacturer}");
+        Console.WriteLine($"  Description: {config.Description}");
+        Console.WriteLine($"  Serial Number: {config.SerialNumber}");
+        Console.WriteLine($"  Max Power: {config.MaxPower}mA");
+        Console.WriteLine($"  Channel A: {config.ChannelA?.DriverType ?? "N/A"} driver");
+        if (config.ChannelB != null)
+        {
+            Console.WriteLine($"  Channel B: {config.ChannelB.DriverType} driver");
+        }
+        Console.WriteLine();
+
+        // Program the EEPROM
+        try
+        {
+            FtdiEeprom.ProgramEeprom(handle, ref eepromData);
+            Console.WriteLine("✓ EEPROM programmed successfully!");
+            Console.WriteLine();
+            Console.WriteLine("═══════════════════════════════════════════════════════");
+            Console.WriteLine("IMPORTANT: Unplug and replug the USB cable now!");
+            Console.WriteLine("═══════════════════════════════════════════════════════");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[ERROR] EEPROM programming failed: {ex.Message}");
+        }
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/FtxEepromProgrammer.csproj
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/FtxEepromProgrammer.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Company>Wilderness Labs, Inc</Company>
+    <Authors>Wilderness Labs, Inc</Authors>
+    <LangVersion>12.0</LangVersion>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Driver\ICs.IOExpanders.Ftxxxx.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="configs\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/Program.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/Program.cs
@@ -1,0 +1,146 @@
+﻿// FTDI EEPROM Programmer - Flexible tool for programming and erasing FTDI EEPROMs
+using Meadow.Foundation.ICs.IOExpanders;
+
+namespace FtxEepromProgrammer;
+
+internal class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("═══════════════════════════════════════════════════════");
+        Console.WriteLine("        FTDI EEPROM Programmer & Configuration Tool");
+        Console.WriteLine("═══════════════════════════════════════════════════════\n");
+
+        try
+        {
+            // Find and display FTDI devices
+            DeviceInfo.DisplayDevices();
+            var count = FtdiExpanderCollection.Devices.Count;
+
+            int deviceIndex = 0;
+
+            if (count == 0)
+            {
+                Console.WriteLine("This can happen if the EEPROM is corrupted or blank.");
+                Console.WriteLine("\nAttempting to open device at index 0 anyway...");
+                Console.WriteLine("(The device may still be accessible even if not enumerated)");
+                
+                // Actually try to open the device to see if it's accessible
+                try
+                {
+                    var testHandle = FtdiEeprom.OpenDevice(0);
+                    Console.WriteLine("✓ Successfully opened device at index 0!");
+                    Console.WriteLine("  This device has a corrupted/blank EEPROM but is accessible.\n");
+                    FtdiEeprom.CloseDevice(testHandle);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"✗ Failed to open device at index 0: {ex.Message}");
+                    Console.WriteLine("\nThe device is not accessible via standard methods.");
+                    Console.WriteLine("TIP: Try option [4] Recovery Mode for bricked devices.\n");
+                    // Don't return - continue to menu so user can try Recovery Mode
+                }
+            }
+            else
+            {
+                // Select device
+                Console.Write("Select device index [0]: ");
+                var input = Console.ReadLine();
+                deviceIndex = string.IsNullOrWhiteSpace(input) ? 0 : int.Parse(input);
+
+                if (deviceIndex < 0 || deviceIndex >= count)
+                {
+                    Console.WriteLine("Invalid device index.");
+                    return;
+                }
+
+                // Close all devices (we need exclusive access)
+                Console.WriteLine("\nClosing all devices...");
+                foreach (var device in FtdiExpanderCollection.Devices)
+                {
+                    device.Dispose();
+                }
+            }
+
+            // Show menu
+            Console.WriteLine("\n═══════════════════════════════════════════════════════");
+            Console.WriteLine("Select operation:");
+            Console.WriteLine("  [1] View EEPROM details");
+            Console.WriteLine("  [2] Erase EEPROM (restore to blank/default state)");
+            Console.WriteLine("  [3] Program from config file");
+            Console.WriteLine("  [4] Recovery Mode (for bricked devices)");
+            Console.WriteLine("  [5] Diagnostic Tests");
+            Console.WriteLine("  [6] Cancel");
+            Console.Write("\nChoice [1]: ");
+            var input2 = Console.ReadLine();
+            var choice = string.IsNullOrWhiteSpace(input2) ? 1 : int.Parse(input2);
+
+            // Check for cancel or recovery mode (don't need device open)
+            if (choice == 6)
+            {
+                Console.WriteLine("Cancelled.");
+                return;
+            }
+
+            if (choice == 5)
+            {
+                // Diagnostic tests
+                DiagnosticTests.TestFtEeRead();
+                return;
+            }
+
+            if (choice == 4)
+            {
+                // Recovery mode - handles device opening internally
+                RecoveryMode.AttemptRecovery();
+                return;
+            }
+
+            if (choice < 1 || choice > 3)
+            {
+                Console.WriteLine("Invalid choice.");
+                return;
+            }
+
+            // Open device for EEPROM access using driver API
+            Console.WriteLine($"\nOpening device [{deviceIndex}] for EEPROM access...");
+            IntPtr handle;
+            try
+            {
+                handle = FtdiEeprom.OpenDevice((uint)deviceIndex);
+                Console.WriteLine("Device opened successfully\n");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to open device: {ex.Message}");
+                return;
+            }
+
+            try
+            {
+                switch (choice)
+                {
+                    case 1:
+                        DeviceInfo.DisplayEepromInfo(handle);
+                        break;
+                    case 2:
+                        EepromOperations.EraseEeprom(handle);
+                        break;
+                    case 3:
+                        EepromOperations.ProgramFromConfig(handle);
+                        break;
+                }
+            }
+            finally
+            {
+                FtdiEeprom.CloseDevice(handle);
+                Console.WriteLine("\nDevice closed");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"\n[ERROR] {ex.Message}");
+            Console.WriteLine(ex.StackTrace);
+        }
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/README.md
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/README.md
@@ -1,0 +1,254 @@
+# FTDI EEPROM Programmer
+
+A command-line utility for programming and managing FTDI device EEPROMs (FT232H, FT2232H, etc.).
+
+## Features
+
+- **View EEPROM Details** - Read and display current EEPROM configuration.
+- **Erase EEPROM** - Restore device to factory default/blank state.
+- **Program from Config** - Program EEPROM using JSON configuration files.
+- **Recovery Mode** - Attempt to recover bricked devices with corrupted EEPROMs.
+
+## Prerequisites
+
+### macOS
+- **D2xxHelper** must be installed to prevent Apple's VCP driver from claiming FTDI devices
+- Download from: https://ftdichip.com/drivers/d2xx-drivers/
+- Install the D2xxHelper package and reboot
+
+### All Platforms
+- .NET 8.0 SDK or later
+- FTDI D2XX driver installed
+
+## Usage
+
+```bash
+dotnet run
+```
+
+The tool will:
+1. Detect connected FTDI devices
+2. Display device information
+3. Present a menu of operations
+
+### Menu Options
+
+**[1] View EEPROM Details**
+- Reads and displays current EEPROM configuration.
+- Shows VID/PID, manufacturer, description, serial number, and channel settings.
+
+**[2] Erase EEPROM**
+- Erases the EEPROM, restoring device to blank/factory default state.
+- Requires confirmation.
+- Device must be unplugged/replugged after erasing
+
+**[3] Program from Config File**
+- Programs EEPROM using a JSON configuration file.
+- Validates configuration before programming.
+- Automatically detects FT232H vs FT2232H based on Product ID.
+
+**[4] Recovery Mode**
+- Attempts to recover bricked devices with corrupted EEPROMs.
+- Tries multiple access strategies:
+  - Opening by device index.
+  - Opening by USB location ID.
+  - Aggressive recovery with device reset.
+
+**[5] Diagnostic Tests**
+- Test FT_EE_Read functionality for debugging.
+
+**[6] Cancel**
+- Exit without performing any operation.
+
+## Configuration Files
+
+Configuration files are located in the `configs/` directory:
+
+- **`ft232h.json`** - Generic FT232H configuration.
+- **`ft232h_adafruit.json`** - Adafruit FT232H specific configuration.
+- **`ft2232h.json`** - Generic FT2232H dual-channel configuration.
+
+### Configuration Format
+
+```json
+{
+    "deviceType": "FT232H",
+    "vendorId": "0x0403",
+    "productId": "0x6014",
+    "manufacturer": "FTDI",
+    "manufacturerId": "FT",
+    "description": "Adafruit FT232H",
+    "serialNumber": "ADAFT01",
+    "maxPower": 500,
+    "pnp": true,
+    "selfPowered": false,
+    "remoteWakeup": true,
+    "pullDownEnable": true,
+    "serNumEnable": true,
+    "usbVersionEnable": true,
+    "usbVersion": "0x0200",
+    "channelA": {
+        "isHighCurrent": false,
+        "isVCP": false,
+        "isFifo": false,
+        "isFifoTarget": false,
+        "isFastSer": false,
+        "driverType": "D2XX"
+    }
+}
+```
+
+### Key Configuration Fields
+
+- **`vendorId`** - USB Vendor ID (0x0403 for FTDI).
+- **`productId`** - USB Product ID
+  - `0x6014` for FT232H (single-channel).
+  - `0x6010` for FT2232H (dual-channel).
+- **`driverType`** - "D2XX" or "VCP"
+  - D2XX: Direct driver access (recommended for Meadow.Foundation).
+  - VCP: Virtual COM Port mode.
+
+## Safety Features
+
+The tool includes several safety features to prevent bricking devices:
+
+1. **Configuration Validation** - Checks for empty/missing critical fields (VID/PID).
+2. **Device Type Detection** - Automatically uses correct EEPROM structure based on Product ID.
+3. **Confirmation Prompts** - Requires confirmation before destructive operations.
+4. **Error Handling** - Graceful error messages with recovery suggestions.
+
+## Troubleshooting
+
+### Device Not Detected
+
+**Symptoms:**
+- "No FTDI devices found"
+- Device shows in System Information but not in tool
+
+**Solutions:**
+1. Verify D2xxHelper is installed (macOS).
+2. Unplug and replug the device.
+3. Try a different USB port.
+4. Check if device has corrupted EEPROM (VID/PID shows as 0xFFFF/0xFFFF).
+
+### Blank EEPROM (Fresh Device)
+
+**Symptoms:**
+- Device detected but shows empty description/serial.
+- "FT_INVALID_PARAMETER" error when viewing EEPROM details.
+
+**This is normal!** Fresh Adafruit FT232H boards come with blank EEPROMs. Simply program them using option [3].
+
+### Bricked Device Recovery
+
+If a device has been bricked (corrupted EEPROM with invalid VID/PID):
+
+#### Option 1: Recovery Mode (Try First)
+
+```bash
+dotnet run
+# Select [4] Recovery Mode
+```
+
+The tool will attempt multiple recovery strategies. If successful, the EEPROM will be erased and the device restored to blank state.
+
+#### Option 2: libftdi (macOS/Linux)
+
+If Recovery Mode fails, try using `libftdi`:
+
+```bash
+# Install libftdi
+brew install libftdi
+
+# Create a recovery config
+cat > ftdi_recovery.conf << EOF
+vendor_id=0xffff
+product_id=0xffff
+filename="eeprom.bin"
+EOF
+
+# Try to erase the EEPROM
+sudo ftdi_eeprom --erase-eeprom ftdi_recovery.conf
+```
+
+**Note:** This may not work if the VID/PID is completely corrupted, as the driver may not recognize the device.
+
+#### Option 3: FT_Prog (Windows - Most Reliable)
+
+For severely bricked devices, use FTDI's official FT_Prog utility on Windows:
+
+1. **Download FT_Prog**
+   - https://ftdichip.com/utilities/#ft_prog
+   - Windows-only (use VM with USB passthrough on Mac/Linux).
+
+2. **Use Programming Mode**
+   - Launch FT_Prog.
+   - Devices → "Scan for devices in programming mode".
+   - This can access devices even with corrupted VID/PID.
+
+3. **Erase or Reprogram**
+   - Right-click device → Erase.
+   - Or load a template and program.
+
+#### Option 4: Hardware Recovery
+
+If all software methods fail, some FTDI chips support hardware recovery:
+
+1. Short specific pins during power-up (consult chip datasheet).
+2. This forces the chip into programming mode.
+3. Use FT_Prog to reprogram.
+
+**⚠️ Warning:** Hardware recovery should be a last resort and requires careful attention to the datasheet.
+
+## Common Issues
+
+### "Native error: FT_DEVICE_NOT_FOUND"
+
+**Cause:** Device not accessible through FTDI driver.
+
+**Solutions:**
+- Check D2xxHelper is installed (macOS).
+- Verify device is plugged in.
+- Try Recovery Mode if EEPROM is corrupted.
+
+### "Configuration has missing critical fields!"
+
+**Cause:** JSON configuration file has empty VID or PID.
+
+**Solution:** Check the JSON file and ensure `vendorId` and `productId` are set correctly.
+
+### Device Shows as "Ft232BOrFt245B (0)"
+
+**Cause:** Blank EEPROM - device is using default type detection.
+
+**Solution:** This is normal for unprogrammed devices. Program using option [3].
+
+## Development Notes
+
+### EEPROM API Differences
+
+FTDI devices use different EEPROM programming APIs:
+
+- **FT232H** - Single-channel, uses older `FT_EE_Program` API with `FT_PROGRAM_DATA` structure (Version=5).
+- **FT2232H** - Dual-channel, uses newer `FT_EEPROM_Program` API with `FT_EEPROM_2232H` structure.
+
+The tool automatically selects the correct API and structure based on the Product ID.
+
+### Adding New Device Support
+
+To add support for other FTDI devices:
+
+1. Add the EEPROM structure to `Driver/Native.Ftd2xx.cs`.
+2. Add P/Invoke declarations for the new structure.
+3. Update `FtdiEeprom.ProgramEeprom()` to detect and use the new structure.
+4. Create a JSON configuration template in `configs/`.
+
+## License
+
+This tool is part of Meadow.Foundation and is licensed under the Apache 2.0 license.
+
+## Support
+
+For issues or questions:
+- GitHub Issues: https://github.com/WildernessLabs/Meadow.Foundation/issues
+- Wilderness Labs Community: https://community.wildernesslabs.co/

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/RecoveryMode.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/RecoveryMode.cs
@@ -1,0 +1,173 @@
+using Meadow.Foundation.ICs.IOExpanders;
+
+namespace FtxEepromProgrammer;
+
+/// <summary>
+/// Recovery operations for bricked FTDI devices
+/// </summary>
+internal static class RecoveryMode
+{
+    /// <summary>
+    /// Attempts to recover a bricked FTDI device by trying multiple access methods
+    /// </summary>
+    public static void AttemptRecovery()
+    {
+        Console.WriteLine("═══════════════════════════════════════════════════════");
+        Console.WriteLine("RECOVERY MODE - Bricked Device Recovery");
+        Console.WriteLine("═══════════════════════════════════════════════════════\n");
+        Console.WriteLine("This mode attempts to recover FTDI devices with corrupted");
+        Console.WriteLine("EEPROM (e.g., VID/PID showing as 0xFFFF/0xFFFF).\n");
+        Console.WriteLine("Recovery strategies:");
+        Console.WriteLine("  1. Try opening by index (0-3)");
+        Console.WriteLine("  2. Try opening by location ID");
+        Console.WriteLine("  3. Scan USB bus for FTDI devices\n");
+        
+        Console.Write("Continue with recovery attempt? [y/N]: ");
+        var confirm = Console.ReadLine();
+        if (confirm?.ToLower() != "y")
+        {
+            Console.WriteLine("Cancelled.");
+            return;
+        }
+
+        Console.WriteLine("\n" + new string('─', 55));
+        Console.WriteLine("RECOVERY ATTEMPT");
+        Console.WriteLine(new string('─', 55) + "\n");
+
+        IntPtr handle = IntPtr.Zero;
+        bool deviceOpened = false;
+
+        // Strategy 1: Try opening by index 0-3
+        Console.WriteLine("[1/3] Trying to open by device index...");
+        for (uint i = 0; i < 4; i++)
+        {
+            Console.Write($"  Trying index {i}... ");
+            try
+            {
+                handle = FtdiEeprom.OpenDevice(i);
+                Console.WriteLine("✓ SUCCESS!");
+                deviceOpened = true;
+                break;
+            }
+            catch
+            {
+                Console.WriteLine("✗ Failed");
+            }
+        }
+
+        // Strategy 2: Try opening by location ID (common values)
+        if (!deviceOpened)
+        {
+            Console.WriteLine("\n[2/3] Trying to open by location ID...");
+            uint[] commonLocations = { 0x0, 0x1, 0x10, 0x11, 0x20, 0x21, 0x22112100 };
+            
+            foreach (var loc in commonLocations)
+            {
+                Console.Write($"  Trying location 0x{loc:X8}... ");
+                try
+                {
+                    handle = FtdiEeprom.TryOpenByLocation(loc);
+                    if (handle != IntPtr.Zero)
+                    {
+                        Console.WriteLine("✓ SUCCESS!");
+                        deviceOpened = true;
+                        break;
+                    }
+                    Console.WriteLine("✗ Failed");
+                }
+                catch
+                {
+                    Console.WriteLine("✗ Failed");
+                }
+            }
+        }
+
+        // Strategy 3: Try brute force with reset
+        if (!deviceOpened)
+        {
+            Console.WriteLine("\n[3/3] Trying aggressive recovery...");
+            Console.WriteLine("  This may cause the device to disconnect/reconnect.");
+            
+            for (uint i = 0; i < 2; i++)
+            {
+                try
+                {
+                    Console.Write($"  Attempt {i + 1}... ");
+                    handle = FtdiEeprom.OpenDevice(i);
+                    if (handle != IntPtr.Zero)
+                    {
+                        // Try to reset the device
+                        FtdiEeprom.ResetDevice(handle);
+                        System.Threading.Thread.Sleep(500);
+                        Console.WriteLine("✓ Device opened and reset");
+                        deviceOpened = true;
+                        break;
+                    }
+                    Console.WriteLine("✗ Failed");
+                }
+                catch
+                {
+                    Console.WriteLine("✗ Failed");
+                }
+            }
+        }
+
+        Console.WriteLine();
+
+        if (!deviceOpened)
+        {
+            Console.WriteLine("═══════════════════════════════════════════════════════");
+            Console.WriteLine("RECOVERY FAILED");
+            Console.WriteLine("═══════════════════════════════════════════════════════\n");
+            Console.WriteLine("Unable to access the device using any method.");
+            Console.WriteLine("\nPossible solutions:");
+            Console.WriteLine("  1. Use FTDI's FT_Prog utility on Windows");
+            Console.WriteLine("  2. Try a different USB port");
+            Console.WriteLine("  3. Unplug/replug the device and try again");
+            Console.WriteLine("  4. Check if D2xxHelper is installed (macOS)");
+            Console.WriteLine("  5. Device may need hardware recovery\n");
+            return;
+        }
+
+        // Device opened successfully - try to erase EEPROM
+        try
+        {
+            Console.WriteLine("═══════════════════════════════════════════════════════");
+            Console.WriteLine("DEVICE ACCESSED - Attempting EEPROM Erase");
+            Console.WriteLine("═══════════════════════════════════════════════════════\n");
+            
+            Console.WriteLine("Erasing EEPROM...");
+            FtdiEeprom.EraseEeprom(handle);
+            
+            Console.WriteLine("✓ EEPROM erased successfully!\n");
+            Console.WriteLine("═══════════════════════════════════════════════════════");
+            Console.WriteLine("RECOVERY SUCCESSFUL!");
+            Console.WriteLine("═══════════════════════════════════════════════════════\n");
+            Console.WriteLine("The device EEPROM has been erased.");
+            Console.WriteLine("\nIMPORTANT: Unplug and replug the USB cable now!");
+            Console.WriteLine("\nThe device should now appear as a blank FT232H or FT2232H");
+            Console.WriteLine("and can be programmed normally.\n");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"\n✗ EEPROM erase failed: {ex.Message}\n");
+            Console.WriteLine("The device was accessible but EEPROM erase failed.");
+            Console.WriteLine("This may indicate hardware damage or protection.\n");
+        }
+        finally
+        {
+            if (handle != IntPtr.Zero)
+            {
+                try
+                {
+                    FtdiEeprom.CloseDevice(handle);
+                    Console.WriteLine("Device closed.");
+                }
+                catch
+                {
+                    // Ignore close errors
+                }
+            }
+        }
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/configs/ft2232h.json
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/configs/ft2232h.json
@@ -1,0 +1,33 @@
+{
+  "deviceType": "FT2232H",
+  "vendorId": "0x0403",
+  "productId": "0x6010",
+  "manufacturer": "FTDI",
+  "manufacturerId": "FT",
+  "description": "Dual RS232-HS",
+  "serialNumber": "FT2232H01",
+  "maxPower": 500,
+  "pnp": true,
+  "selfPowered": false,
+  "remoteWakeup": true,
+  "pullDownEnable": true,
+  "serNumEnable": true,
+  "usbVersionEnable": true,
+  "usbVersion": "0x0200",
+  "channelA": {
+    "isHighCurrent": false,
+    "isVCP": false,
+    "isFifo": false,
+    "isFifoTarget": false,
+    "isFastSer": false,
+    "driverType": "D2XX"
+  },
+  "channelB": {
+    "isHighCurrent": false,
+    "isVCP": false,
+    "isFifo": false,
+    "isFifoTarget": false,
+    "isFastSer": false,
+    "driverType": "D2XX"
+  }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/configs/ft2232h_wilderness_labs.json
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/configs/ft2232h_wilderness_labs.json
@@ -1,0 +1,33 @@
+{
+    "deviceType": "FT2232H",
+    "vendorId": "0x0403",
+    "productId": "0x6010",
+    "manufacturer": "Wilderness Labs",
+    "manufacturerId": "FT",
+    "description": "Dual RS232-HS module",
+    "serialNumber": "FT2232H01",
+    "maxPower": 500,
+    "pnp": true,
+    "selfPowered": false,
+    "remoteWakeup": true,
+    "pullDownEnable": true,
+    "serNumEnable": true,
+    "usbVersionEnable": true,
+    "usbVersion": "0x0200",
+    "channelA": {
+        "isHighCurrent": false,
+        "isVCP": false,
+        "isFifo": false,
+        "isFifoTarget": false,
+        "isFastSer": false,
+        "driverType": "D2XX"
+    },
+    "channelB": {
+        "isHighCurrent": false,
+        "isVCP": false,
+        "isFifo": false,
+        "isFifoTarget": false,
+        "isFastSer": false,
+        "driverType": "D2XX"
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/configs/ft232h.json
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/configs/ft232h.json
@@ -1,0 +1,25 @@
+{
+    "deviceType": "FT232H",
+    "vendorId": "0x0403",
+    "productId": "0x6014",
+    "manufacturer": "FTDI",
+    "manufacturerId": "FT",
+    "description": "FT232H",
+    "serialNumber": "FT232H01",
+    "maxPower": 500,
+    "pnp": true,
+    "selfPowered": false,
+    "remoteWakeup": true,
+    "pullDownEnable": true,
+    "serNumEnable": true,
+    "usbVersionEnable": true,
+    "usbVersion": "0x0200",
+    "channelA": {
+        "isHighCurrent": false,
+        "isVCP": false,
+        "isFifo": false,
+        "isFifoTarget": false,
+        "isFastSer": false,
+        "driverType": "D2XX"
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/configs/ft232h_adafruit.json
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Ftxxxx/Samples/FtxEepromProgrammer/configs/ft232h_adafruit.json
@@ -1,0 +1,25 @@
+{
+    "deviceType": "FT232H",
+    "vendorId": "0x0403",
+    "productId": "0x6014",
+    "manufacturer": "FTDI",
+    "manufacturerId": "FT",
+    "description": "Adafruit FT232H",
+    "serialNumber": "ADAFT01",
+    "maxPower": 500,
+    "pnp": true,
+    "selfPowered": false,
+    "remoteWakeup": true,
+    "pullDownEnable": true,
+    "serNumEnable": true,
+    "usbVersionEnable": true,
+    "usbVersion": "0x0200",
+    "channelA": {
+        "isHighCurrent": false,
+        "isVCP": false,
+        "isFifo": false,
+        "isFifoTarget": false,
+        "isFastSer": false,
+        "driverType": "D2XX"
+    }
+}


### PR DESCRIPTION
- Add FtxEepromProgrammer sample application for programming FTDI device EEPROMs on macOS
- Support FT232H (single-channel) using FT_EE_Program API with FT_PROGRAM_DATA structure
- Support FT2232H (dual-channel) using FT_EEPROM_Program API with FT_EEPROM_2232H structure
- Add JSON configuration files for common device profiles (Adafruit FT232H, generic FT232H/FT2232H)
- Include recovery mode for bricked devices with corrupted EEPROMs
- Add FT_EEPROM_HEADER struct and complete FT_PROGRAM_DATA (~150 fields) to Native.Ftd2xx.cs
- Add comprehensive README with usage instructions and troubleshooting guide Tested on macOS with D2xxHelper driver. Both read and write operations verified working.