### PR TITLE
Fix multiple bugs in Apa102 and SparkFunQwiicLEDStick drivers

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Leds.Apa102/Driver/Apa102.Display.cs
+++ b/Source/Meadow.Foundation.Peripherals/Leds.Apa102/Driver/Apa102.Display.cs
@@ -104,11 +104,11 @@ namespace Meadow.Foundation.Leds
         /// <param name="y">y position of pixel</param>
         public void InvertPixel(int x, int y)
         {
-            var index = 3 * GetIndexForCoordinate(x, y);
+            var offset = StartHeaderSize + GetIndexForCoordinate(x, y) * 4 + 1;
 
-            buffer[index] ^= 0xFF;
-            buffer[index + 1] ^= 0xFF;
-            buffer[index + 2] ^= 0xFF;
+            buffer[offset] ^= 0xFF;
+            buffer[offset + 1] ^= 0xFF;
+            buffer[offset + 2] ^= 0xFF;
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace Meadow.Foundation.Leds
             {
                 for (int j = 0; j < height; j++)
                 {
-                    DrawPixel(i, j, fillColor);
+                    DrawPixel(x + i, y + j, fillColor);
                 }
             }
         }

--- a/Source/Meadow.Foundation.Peripherals/Leds.Apa102/Driver/Apa102.cs
+++ b/Source/Meadow.Foundation.Peripherals/Leds.Apa102/Driver/Apa102.cs
@@ -80,7 +80,7 @@ namespace Meadow.Foundation.Leds
         public float Brightness
         {
             get => brightness;
-            set => brightness = Math.Clamp(brightness, 0.0f, 1.0f);
+            set => brightness = Math.Clamp(value, 0.0f, 1.0f);
         }
         float brightness = 0.5f;
 
@@ -185,7 +185,7 @@ namespace Meadow.Foundation.Leds
         /// <param name="brightness">The brightness 0.0 - 1.0f</param>
         public virtual void SetLed(int index, byte[] rgb, float brightness = 1f)
         {
-            if (index > numberOfLeds || index < 0)
+            if (index >= numberOfLeds || index < 0)
             {
                 throw new ArgumentOutOfRangeException("Index must be less than the number of leds specified");
             }
@@ -221,6 +221,8 @@ namespace Meadow.Foundation.Leds
             {
                 SetLed(i, off);
             }
+
+            if (update) Show();
         }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Peripherals/Leds.Apa102/Driver/Apa102PixelBuffer.cs
+++ b/Source/Meadow.Foundation.Peripherals/Leds.Apa102/Driver/Apa102PixelBuffer.cs
@@ -33,11 +33,14 @@ namespace Meadow.Foundation.Leds
         /// <returns></returns>
         public Color GetPixel(int x, int y)
         {
-            var index = 3 * GetIndexForCoordinate(x, y);
+            var offset = StartHeaderSize + GetIndexForCoordinate(x, y) * 4 + 1;
 
-            return new Color(red: buffer[index + pixelOrder[0]],
-                             green: buffer[index + pixelOrder[1]],
-                             blue: buffer[index + pixelOrder[2]]);
+            byte[] rgb = new byte[3];
+            rgb[pixelOrder[0]] = buffer[offset];
+            rgb[pixelOrder[1]] = buffer[offset + 1];
+            rgb[pixelOrder[2]] = buffer[offset + 2];
+
+            return new Color(red: rgb[0], green: rgb[1], blue: rgb[2]);
         }
 
         /// <summary>

--- a/Source/Meadow.Foundation.Peripherals/Leds.Apa102/Driver/SparkFunQwiicLEDStick.cs
+++ b/Source/Meadow.Foundation.Peripherals/Leds.Apa102/Driver/SparkFunQwiicLEDStick.cs
@@ -136,9 +136,9 @@ namespace Meadow.Foundation.Leds
         /// <param name="brightness">The brightness 0.0 - 1.0f</param>
         public virtual void SetLed(int index, byte[] rgb, float brightness = 1f)
         {
-            if (rgb.Length % 3 != 0)
+            if (rgb.Length != 3)
             {
-                throw new ArgumentException("Data length must be a multiple of 3 (RGB sets).");
+                throw new ArgumentException("rgb must be a 3-element array (Red, Green, Blue).");
             }
 
             var requestedBrightness = ConvertBrightness(brightness);
@@ -233,7 +233,10 @@ namespace Meadow.Foundation.Leds
             Array.Clear(buffer[2], 0, buffer[0].Length);
             Array.Clear(buffer[3], 0, buffer[0].Length);
 
-            base.Write((byte)Register.AllOff);
+            if (update)
+            {
+                base.Write((byte)Register.AllOff);
+            }
         }
     }
 }


### PR DESCRIPTION
- Apa102: Brightness setter was clamping the backing field instead of the incoming value, making it impossible to change brightness
- Apa102: SetLed bounds check used > instead of >=, allowing out-of-bounds write at index == numberOfLeds
- Apa102: Clear(bool update) ignored the update parameter and never called Show()
- Apa102: InvertPixel used wrong buffer offset (3*index instead of StartHeaderSize + index*4 + 1)
- Apa102: GetPixel used same wrong buffer offset as InvertPixel
- Apa102: Fill(x,y,w,h) ignored the x and y parameters, always filling from origin
- SparkFunQwiicLEDStick: Clear always sent AllOff to hardware regardless of the update parameter
- SparkFunQwiicLEDStick: SetLed rgb validation checked % 3 != 0 instead of != 3