### PR TITLE
Fix multiple bugs in WiiExtensionControllers driver

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/Controls/WiiExtensionAnalogTrigger.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/Controls/WiiExtensionAnalogTrigger.cs
@@ -13,7 +13,7 @@ namespace Meadow.Foundation.Sensors.Hid
 
         public WiiExtensionAnalogTrigger(byte precision)
         {
-            precisionMultiplier = 1.0 / Math.Pow(2, precision);
+            precisionMultiplier = 1.0 / (Math.Pow(2, precision) - 1);
         }
 
         public void Update(byte triggerPosition)

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/Controls/WiiExtensionButton.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/Controls/WiiExtensionButton.cs
@@ -61,10 +61,7 @@ namespace Meadow.Foundation.Sensors.Hid
                     RaiseClicked();
                 }
 
-                if (pressDuration.TotalMilliseconds > 0)
-                {
-                    RaisePressEnded();
-                }
+                RaisePressEnded();
             }
 
             State = state;

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/Drivers/WiiClassicController.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/Drivers/WiiClassicController.cs
@@ -85,10 +85,8 @@ namespace Meadow.Foundation.Sensors.Hid
         /// </summary>
         /// <param name="i2cBus">the I2C bus connected to controller</param>
         /// <param name="useHighResolutionMode">Enable high resolution mode analog sticks and triggers (8 bits of precision)</param>
-        public WiiClassicController(II2cBus i2cBus, bool useHighResolutionMode = false) : base(i2cBus, (byte)Addresses.Default)
+        public WiiClassicController(II2cBus i2cBus, bool useHighResolutionMode = false) : base(i2cBus, (byte)Addresses.Default, useHighResolutionMode)
         {
-            this.useHighResolutionMode = useHighResolutionMode;
-
             LeftAnalogStick = new WiiExtensionAnalogJoystick((byte)(useHighResolutionMode ? 8 : 6));
             RightAnalogStick = new WiiExtensionAnalogJoystick((byte)(useHighResolutionMode ? 8 : 5));
             LeftTrigger = new WiiExtensionAnalogTrigger((byte)(useHighResolutionMode ? 8 : 5));

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/Drivers/WiiClassicControllerPro.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/Drivers/WiiClassicControllerPro.cs
@@ -76,10 +76,8 @@ namespace Meadow.Foundation.Sensors.Hid
         /// </summary>
         /// <param name="i2cBus">the I2C bus connected to controller</param>
         /// <param name="useHighResolutionMode">Enable high resolution mode analog sticks and triggers (8 bits of precision)</param>
-        public WiiClassicControllerPro(II2cBus i2cBus, bool useHighResolutionMode = false) : base(i2cBus, (byte)Addresses.Default)
+        public WiiClassicControllerPro(II2cBus i2cBus, bool useHighResolutionMode = false) : base(i2cBus, (byte)Addresses.Default, useHighResolutionMode)
         {
-            this.useHighResolutionMode = useHighResolutionMode;
-
             LeftAnalogStick = new WiiExtensionAnalogJoystick((byte)(useHighResolutionMode ? 8 : 6));
             RightAnalogStick = new WiiExtensionAnalogJoystick((byte)(useHighResolutionMode ? 8 : 5));
         }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/WiiClassicControllerBase.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/WiiClassicControllerBase.cs
@@ -119,8 +119,16 @@ namespace Meadow.Foundation.Sensors.Hid
         /// </summary>
         /// <param name="i2cBus">the I2C bus connected to the extension controller</param>
         /// <param name="address">The extension controller address</param>
-        protected WiiClassicControllerBase(II2cBus i2cBus, byte address) : base(i2cBus, address)
+        /// <param name="useHighResolutionMode">Enable high resolution mode for analog controls</param>
+        protected WiiClassicControllerBase(II2cBus i2cBus, byte address, bool useHighResolutionMode = false) : base(i2cBus, address)
         {
+            // base constructor calls Initialize() via virtual dispatch before this field is set,
+            // so we set it here and re-apply the mode register with the correct value
+            if (useHighResolutionMode)
+            {
+                this.useHighResolutionMode = true;
+                i2cComms.WriteRegister(0xFE, 0x03);
+            }
         }
 
         /// <summary>
@@ -129,14 +137,9 @@ namespace Meadow.Foundation.Sensors.Hid
         protected override void Initialize()
         {
             base.Initialize();
-            if (useHighResolutionMode)
-            {
-                i2cComms.WriteRegister(0xFE, 0x03);
-            }
-            else
-            {
-                i2cComms.WriteRegister(0xFE, 0x00);
-            }
+            // useHighResolutionMode is always false here due to virtual call in base constructor;
+            // the correct register value is written in the WiiClassicControllerBase constructor body
+            i2cComms.WriteRegister(0xFE, 0x00);
         }
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/WiiExtensionControllerBase.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Hid.WiiExtensionControllers/Driver/WiiExtensionControllerBase.cs
@@ -85,12 +85,10 @@ namespace Meadow.Foundation.Sensors.Hid
         /// <returns>The ID as a byte</returns>
         public byte[] GetIdentification()
         {
+            var idBuffer = new byte[6];
             i2cComms.Write(0xFA);
-            i2cComms.Read(ReadBuffer[..6]);
-
-            Resolver.Log.Info(BitConverter.ToString(ReadBuffer[..6].ToArray()));
-
-            return ReadBuffer[..6].ToArray();
+            i2cComms.Read(idBuffer);
+            return idBuffer;
         }
 
         /// <summary>


### PR DESCRIPTION
- WiiClassicControllerBase: high-res mode was never applied because Initialize() is called via virtual dispatch from the base constructor before useHighResolutionMode is set; fixed by accepting the bool in WiiClassicControllerBase constructor and re-writing register 0xFE after base construction completes
- WiiClassicController/Pro: pass useHighResolutionMode to base constructor and remove redundant field assignment
- WiiExtensionControllerBase: GetIdentification() was clobbering the shared ReadBuffer (corrupting sensor state during sampling) and had debug Resolver.Log.Info left in production code; now uses a dedicated local buffer
- WiiExtensionButton: PressEnded was not raised for zero-duration presses, creating an asymmetric PressStarted/PressEnded pair
- WiiExtensionAnalogTrigger: divided by 2^n instead of 2^n-1, so full trigger deflection never reached 1.0