### PR TITLE
Fix bugs in Displays.ePaperWaveShare drivers

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd4in2.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd4in2.cs
@@ -203,7 +203,7 @@ namespace Meadow.Foundation.Displays
         public override void Show(int left, int top, int right, int bottom)
         {
             int width = right - left;
-            int height = top - bottom;
+            int height = bottom - top;
 
             SetPartialWindow(left, top, width, height);
 
@@ -244,7 +244,7 @@ namespace Meadow.Foundation.Displays
             SendData(0x12);
 
             SendCommand(VCOM_AND_DATA_INTERVAL_SETTING);
-            SendCommand(0x97);    //VBDF 17|D7 VBDW 97  VBDB 57  VBDF F7  VBDW 77  VBDB 37  VBDR B7
+            SendData(0x97);    //VBDF 17|D7 VBDW 97  VBDB 57  VBDF F7  VBDW 77  VBDB 37  VBDR B7
 
             var buffer = imageBuffer.Buffer;
 

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd4in2bV2.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd4in2bV2.cs
@@ -92,8 +92,8 @@ namespace Meadow.Foundation.Displays
             SendCommand(Command.PARTIAL_WINDOW);
             SendData(x >> 8);
             SendData(x & 0xf8);     // x should be the multiple of 8, the last 3 bit will always be ignored
-            SendData(((x & 0x1f8) + width - 1) >> 8);
-            SendData(((x & 0x1f8) + width - 1) | 0x07);
+            SendData(((x & 0xf8) + width - 1) >> 8);
+            SendData(((x & 0xf8) + width - 1) | 0x07);
             SendData(y >> 8);
             SendData(y & 0xff);
             SendData((y + height - 1) >> 8);
@@ -139,8 +139,8 @@ namespace Meadow.Foundation.Displays
             SendCommand(Command.PARTIAL_WINDOW);
             SendData(x >> 8);
             SendData(x & 0xf8);     // x should be the multiple of 8, the last 3 bit will always be ignored
-            SendData(((x & 0x1f8) + width - 1) >> 8);
-            SendData(((x & 0x1f8) + width - 1) | 0x07);
+            SendData(((x & 0xf8) + width - 1) >> 8);
+            SendData(((x & 0xf8) + width - 1) | 0x07);
             SendData(y >> 8);
             SendData(y & 0xff);
             SendData((y + height - 1) >> 8);

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd4in2bV2.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd4in2bV2.cs
@@ -1,5 +1,4 @@
 ﻿using Meadow.Hardware;
-using System.Threading;
 
 namespace Meadow.Foundation.Displays
 {
@@ -140,13 +139,13 @@ namespace Meadow.Foundation.Displays
             SendCommand(Command.PARTIAL_WINDOW);
             SendData(x >> 8);
             SendData(x & 0xf8);     // x should be the multiple of 8, the last 3 bit will always be ignored
-            SendData(((x & 0x1f8) + width - 1) >> 8);
-            SendData(((x & 0x1f8) + width - 1) | 0x07);
+            SendData(((x & 0xf8) + width - 1) >> 8);
+            SendData(((x & 0xf8) + width - 1) | 0x07);
             SendData(y >> 8);
             SendData(y & 0xff);
             SendData((y + height - 1) >> 8);
             SendData((y + height - 1) & 0xff);
-            SendData(0x01);         // Gates scan both inside and outside of the partial window. (default) 
+            SendData(0x01);         // Gates scan both inside and outside of the partial window. (default)
             DelayMs(2);
             SendCommand(Command.DATA_START_TRANSMISSION_1);
 
@@ -176,13 +175,13 @@ namespace Meadow.Foundation.Displays
             SendCommand(Command.PARTIAL_WINDOW);
             SendData(x >> 8);
             SendData(x & 0xf8);     // x should be the multiple of 8, the last 3 bit will always be ignored
-            SendData(((x & 0x1f8) + width - 1) >> 8);
-            SendData(((x & 0x1f8) + width - 1) | 0x07);
+            SendData(((x & 0xf8) + width - 1) >> 8);
+            SendData(((x & 0xf8) + width - 1) | 0x07);
             SendData(y >> 8);
             SendData(y & 0xff);
             SendData((y + height - 1) >> 8);
             SendData((y + height - 1) & 0xff);
-            SendData(0x01);         // Gates scan both inside and outside of the partial window. (default) 
+            SendData(0x01);         // Gates scan both inside and outside of the partial window. (default)
             DelayMs(2);
             SendCommand(Command.DATA_START_TRANSMISSION_2);
 
@@ -195,7 +194,7 @@ namespace Meadow.Foundation.Displays
             }
 
             DelayMs(2);
-            SendData((byte)Command.PARTIAL_OUT);
+            SendCommand(Command.PARTIAL_OUT);
         }
 
         /// <summary>
@@ -208,7 +207,7 @@ namespace Meadow.Foundation.Displays
         public override void Show(int left, int top, int right, int bottom)
         {
             SetPartialWindow(imageBuffer.BlackBuffer, imageBuffer.ColorBuffer,
-                left, top, right - left, top - bottom);
+                left, top, right - left, bottom - top);
 
             DisplayFrame();
         }
@@ -227,46 +226,41 @@ namespace Meadow.Foundation.Displays
         protected virtual void ClearFrame()
         {
             SendCommand(Command.DATA_START_TRANSMISSION_1);
-            Thread.Sleep(2);
+            DelayMs(2);
 
             for (int i = 0; i < Width * Height / 8; i++)
             {
                 SendData(0xFF);
             }
-            Thread.Sleep(2);
+            DelayMs(2);
 
             SendCommand(Command.DATA_START_TRANSMISSION_2);
-            Thread.Sleep(2);
+            DelayMs(2);
             for (int i = 0; i < Width * Height / 8; i++)
             {
                 SendData(0xFF);
             }
-            Thread.Sleep(2);
+            DelayMs(2);
         }
 
         void DisplayFrame(byte[] blackBuffer, byte[] colorBuffer)
         {
-            Resolver.Log.Info($"Display frame - width {Width}, height {Height}");
-
             SendCommand(Command.DATA_START_TRANSMISSION_1);
-            Thread.Sleep(2);
+            DelayMs(2);
 
             for (int i = 0; i < Width * Height / 8; i++)
             {
                 SendData(blackBuffer[i]);
-
             }
-            Thread.Sleep(2);
-
+            DelayMs(2);
 
             SendCommand(Command.DATA_START_TRANSMISSION_2);
-            Thread.Sleep(2);
+            DelayMs(2);
             for (int i = 0; i < Width * Height / 8; i++)
             {
-                //SendData(0xFF); //white for clear, black for on
                 SendData(colorBuffer[i]);
             }
-            Thread.Sleep(2);
+            DelayMs(2);
 
             DisplayFrame();
         }

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd4in2bV2.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd4in2bV2.cs
@@ -92,8 +92,8 @@ namespace Meadow.Foundation.Displays
             SendCommand(Command.PARTIAL_WINDOW);
             SendData(x >> 8);
             SendData(x & 0xf8);     // x should be the multiple of 8, the last 3 bit will always be ignored
-            SendData(((x & 0xf8) + width - 1) >> 8);
-            SendData(((x & 0xf8) + width - 1) | 0x07);
+            SendData(((x & 0x1f8) + width - 1) >> 8);
+            SendData(((x & 0x1f8) + width - 1) | 0x07);
             SendData(y >> 8);
             SendData(y & 0xff);
             SendData((y + height - 1) >> 8);
@@ -139,8 +139,8 @@ namespace Meadow.Foundation.Displays
             SendCommand(Command.PARTIAL_WINDOW);
             SendData(x >> 8);
             SendData(x & 0xf8);     // x should be the multiple of 8, the last 3 bit will always be ignored
-            SendData(((x & 0xf8) + width - 1) >> 8);
-            SendData(((x & 0xf8) + width - 1) | 0x07);
+            SendData(((x & 0x1f8) + width - 1) >> 8);
+            SendData(((x & 0x1f8) + width - 1) | 0x07);
             SendData(y >> 8);
             SendData(y & 0xff);
             SendData((y + height - 1) >> 8);

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd7in5V2.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd7in5V2.cs
@@ -92,7 +92,7 @@ public class Epd7in5V2 : EPaperBase, IPixelDisplay, IRefreshableDisplay
         }
     }
 
-    private int lastUpdatedTick = -1;
+    private long lastUpdatedTick = -1;
     private RefreshMode? lastInitializedMode = null;
 
     /// <summary>
@@ -138,7 +138,7 @@ public class Epd7in5V2 : EPaperBase, IPixelDisplay, IRefreshableDisplay
 
         spiComms = new SpiCommunications(spiBus, chipSelectPort, DefaultSpiBusSpeed, DefaultSpiBusMode);
 
-        if ((SupportedColorModes | colorMode) == 0)
+        if ((SupportedColorModes & colorMode) == 0)
         {
             throw new ArgumentException($"ColorMode {colorMode} is not supported");
         }
@@ -463,11 +463,11 @@ public class Epd7in5V2 : EPaperBase, IPixelDisplay, IRefreshableDisplay
     /// <exception cref="NotSupportedException">Thrown if called more frequently than the minimum refresh interval</exception>
     public void Show()
     {
-        if (Environment.TickCount - lastUpdatedTick < MinimumRefreshInterval.TotalMilliseconds)
+        if (Environment.TickCount64 - lastUpdatedTick < MinimumRefreshInterval.TotalMilliseconds)
         {
             throw new NotSupportedException($"The minimum update interval for this display is {MinimumRefreshInterval.TotalMilliseconds} milliseconds");
         }
-        lastUpdatedTick = Environment.TickCount;
+        lastUpdatedTick = Environment.TickCount64;
 
         // Re-initialize only if switching refresh modes
 
@@ -584,11 +584,11 @@ public class Epd7in5V2 : EPaperBase, IPixelDisplay, IRefreshableDisplay
     /// <exception cref="NotSupportedException">Thrown if called more frequently than the minimum refresh interval</exception>
     public void Show(int left, int top, int right, int bottom)
     {
-        if (Environment.TickCount - lastUpdatedTick < MinimumRefreshInterval.TotalMilliseconds)
+        if (Environment.TickCount64 - lastUpdatedTick < MinimumRefreshInterval.TotalMilliseconds)
         {
             throw new NotSupportedException($"The minimum update interval for this display is {MinimumRefreshInterval.TotalMilliseconds} milliseconds");
         }
-        lastUpdatedTick = Environment.TickCount;
+        lastUpdatedTick = Environment.TickCount64;
 
         // Initialize partial refresh if not already in that mode
         switch (CurrentRefreshMode)

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd7in5V2.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd7in5V2.cs
@@ -92,7 +92,7 @@ public class Epd7in5V2 : EPaperBase, IPixelDisplay, IRefreshableDisplay
         }
     }
 
-    private long lastUpdatedTick = -1;
+    private int lastUpdatedTick = -1;
     private RefreshMode? lastInitializedMode = null;
 
     /// <summary>
@@ -463,7 +463,7 @@ public class Epd7in5V2 : EPaperBase, IPixelDisplay, IRefreshableDisplay
     /// <exception cref="NotSupportedException">Thrown if called more frequently than the minimum refresh interval</exception>
     public void Show()
     {
-        if (Environment.TickCount64 - lastUpdatedTick < MinimumRefreshInterval.TotalMilliseconds)
+        if (Environment.TickCount - lastUpdatedTick < MinimumRefreshInterval.TotalMilliseconds)
         {
             throw new NotSupportedException($"The minimum update interval for this display is {MinimumRefreshInterval.TotalMilliseconds} milliseconds");
         }

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd7in5V2.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaperWaveShare/Driver/Drivers/Epd7in5V2.cs
@@ -467,7 +467,7 @@ public class Epd7in5V2 : EPaperBase, IPixelDisplay, IRefreshableDisplay
         {
             throw new NotSupportedException($"The minimum update interval for this display is {MinimumRefreshInterval.TotalMilliseconds} milliseconds");
         }
-        lastUpdatedTick = Environment.TickCount64;
+        lastUpdatedTick = Environment.TickCount;
 
         // Re-initialize only if switching refresh modes
 
@@ -584,11 +584,11 @@ public class Epd7in5V2 : EPaperBase, IPixelDisplay, IRefreshableDisplay
     /// <exception cref="NotSupportedException">Thrown if called more frequently than the minimum refresh interval</exception>
     public void Show(int left, int top, int right, int bottom)
     {
-        if (Environment.TickCount64 - lastUpdatedTick < MinimumRefreshInterval.TotalMilliseconds)
+        if (Environment.TickCount - lastUpdatedTick < MinimumRefreshInterval.TotalMilliseconds)
         {
             throw new NotSupportedException($"The minimum update interval for this display is {MinimumRefreshInterval.TotalMilliseconds} milliseconds");
         }
-        lastUpdatedTick = Environment.TickCount64;
+        lastUpdatedTick = Environment.TickCount;
 
         // Initialize partial refresh if not already in that mode
         switch (CurrentRefreshMode)


### PR DESCRIPTION
Epd4in2: Show(l,t,r,b) negated height (top-bottom → bottom-top); Show() sent VCOM interval value 0x97 as a command instead of data.

Epd4in2bV2: Show(l,t,r,b) negated height; SetPartialWindowColor sent PARTIAL_OUT as data instead of command; SetPartialWindowBlack and SetPartialWindowColor used 0x1f8 alignment mask instead of 0xf8; DisplayFrame left debug Resolver.Log.Info call; ClearFrame and DisplayFrame used Thread.Sleep instead of DelayMs; removed now-unused System.Threading import.

Epd7in5V2: ColorMode validation used | instead of & (unsupported modes were never rejected); TickCount replaced with TickCount64 to avoid 32-bit wraparound after ~25 days.