### PR TITLE
Fix partial update bugs in EPaperMonoBase and Il0373 drivers

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Drivers/Il0373.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/Drivers/Il0373.cs
@@ -220,7 +220,7 @@ namespace Meadow.Foundation.Displays
             }
 
             DelayMs(2);
-            SendData((byte)Command.PARTIAL_OUT);
+            SendCommand(Command.PARTIAL_OUT);
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace Meadow.Foundation.Displays
         public override void Show(int left, int top, int right, int bottom)
         {
             SetPartialWindow(imageBuffer.BlackBuffer, imageBuffer.ColorBuffer,
-                left, top, right - left, top - bottom);
+                left, top, right - left, bottom - top);
 
             DisplayFrame();
         }

--- a/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/EPaperMonoBase.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.ePaper/Driver/EPaperMonoBase.cs
@@ -181,7 +181,7 @@ namespace Meadow.Foundation.Displays
         /// </summary>
         public virtual void Show(int left, int top, int right, int bottom)
         {
-            SetFrameMemory(imageBuffer.Buffer, left, top, right - left, top - bottom);
+            SetFrameMemory(imageBuffer.Buffer, left, top, right - left, bottom - top);
             DisplayFrame();
         }
 


### PR DESCRIPTION
- EPaperMonoBase: Show(left, top, right, bottom) passed top-bottom as the height argument, which is negative when top < bottom; this caused SetFrameMemory to bail out early on its height < 0 guard, making partial updates silently do nothing
- Il0373: Same sign error in Show(left, top, right, bottom) passed to SetPartialWindow
- Il0373: SetPartialWindowColor sent PARTIAL_OUT as data (SendData) instead of as a command (SendCommand); SetPartialWindow and SetPartialWindowBlack both correctly used SendCommand