### PR TITLE
Fix lux calculation and transmittance setter in Bh1750

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Sensors.Light.Bh1750/Driver/Bh1750.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Light.Bh1750/Driver/Bh1750.cs
@@ -19,7 +19,7 @@ namespace Meadow.Foundation.Sensors.Light
         public double LightTransmittance
         {
             get => lightTransmittance;
-            set => SetLightTransmittance(lightTransmittance = value);
+            set => SetLightTransmittance(value);
         }
         private double lightTransmittance;
 
@@ -90,7 +90,7 @@ namespace Meadow.Foundation.Sensors.Light
             if (MeasuringMode == MeasuringModes.ContinuouslyHighResolutionMode2 ||
                 MeasuringMode == MeasuringModes.OneTimeHighResolutionMode2)
             {
-                result *= 2;
+                result /= 2;
             }
 
             return new Illuminance(result, IU.Lux);
@@ -125,6 +125,7 @@ namespace Meadow.Foundation.Sensors.Light
 
             BusComms.Write((byte)((byte)Commands.MeasurementTimeHigh | (val >> 5)));
             BusComms.Write((byte)((byte)Commands.MeasurementTimeLow | (val & 0b_0001_1111)));
+            lightTransmittance = transmittance;
         }
     }
 }


### PR DESCRIPTION
HighResolutionMode2 reports 0.5 lx/count so the result must be divided by 2, not multiplied — the previous result *= 2 produced 4x the correct lux value for that mode.

LightTransmittance setter assigned the backing field before calling SetLightTransmittance, so an out-of-range value left the cached field in an invalid state even though nothing was written to hardware. The assignment is now moved to the end of SetLightTransmittance after validation and the I2C writes succeed.