### PR TITLE
Fix SetPanTiltZoom vertical zoom byte and inverted return value

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Sensors.Camera.Vc0706/Driver/Vc0706.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Camera.Vc0706/Driver/Vc0706.cs
@@ -325,11 +325,11 @@ namespace Meadow.Foundation.Sensors.Camera
         {
             byte[] args = {0x08,
                             (byte)(horizontalZoom >> 8), (byte)horizontalZoom,
-                            (byte)(verticalZoom >> 8), (byte)horizontalZoom,
+                            (byte)(verticalZoom >> 8), (byte)verticalZoom,
                             (byte)(pan >> 8), (byte)pan,
                             (byte)(tilt >> 8), (byte)tilt};
 
-            return (!RunCommand(SET_ZOOM, args, (byte)args.Length, 5));
+            return RunCommand(SET_ZOOM, args, (byte)args.Length, 5);
         }
 
         /// <summary>


### PR DESCRIPTION
Vertical zoom low byte was sending (byte)horizontalZoom instead of (byte)verticalZoom, so vertical zoom was always set to the wrong value.

Return value was negated — RunCommand returns true on success so !RunCommand returned false on success and true on failure, opposite of every other method in the class.