### PR TITLE
Fix SevenSegment SetDisplay ignoring uppercase A-F characters

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Displays.Led.SevenSegment/Driver/SevenSegment.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Led.SevenSegment/Driver/SevenSegment.cs
@@ -227,6 +227,8 @@ namespace Meadow.Foundation.Displays.Led
                 charType = (CharacterType)(character - '0');
             else if (character >= 'a' && character <= 'f')
                 charType = (CharacterType)(character - 'a' + 10);
+            else if (character >= 'A' && character <= 'F')
+                charType = (CharacterType)(character - 'A' + 10);
             else
                 throw new ArgumentOutOfRangeException();
 


### PR DESCRIPTION
Passing 'A'-'F' to SetDisplay(char) threw ArgumentOutOfRangeException; uppercase hex digits now map to the same CharacterType values (10-15) as their lowercase equivalents.