### PR TITLE
Fix Sh110x SPI totalPages not initialized and partial update page ran…

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Displays.Sh110x/Driver/Sh110x.cs
+++ b/Source/Meadow.Foundation.Peripherals/Displays.Sh110x/Driver/Sh110x.cs
@@ -182,6 +182,7 @@ namespace Meadow.Foundation.Displays
             imageBuffer = new Buffer1bpp(Width, Height);
             startColumnOffset = (byte)firstColumn;
             pageWidth = Width;
+            totalPages = height >> 3;
             pageBuffer = new byte[pageWidth];
 
             Initialize();
@@ -352,7 +353,7 @@ namespace Meadow.Foundation.Displays
             // iterate over all pages and check if they're in range
             for (byte page = 0; page < totalPages; page++)
             {
-                if (top > pageHeight * page || bottom < (page + 1) * pageHeight)
+                if (bottom < pageHeight * page || top >= (page + 1) * pageHeight)
                 {
                     continue;
                 }


### PR DESCRIPTION
…ge logic

- SPI constructor omitted totalPages = height >> 3; causing Show() to loop zero times and never send data to the display over SPI
- Show(l,t,r,b) page-skip condition was inverted: skipped pages in range and updated pages outside range; fix: bottom < pageHeight*page || top >= (page+1)*pageHeight