### PR TITLE
Fix MaxBotix StopUpdating inverted Serial condition

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Sensors.Distance.MaxBotix/Driver/MaxBotix.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Distance.MaxBotix/Driver/MaxBotix.cs
@@ -103,7 +103,7 @@ namespace Meadow.Foundation.Sensors.Distance
                 {
                     analogInputPort?.StopUpdating();
                 }
-                else if (communication != CommunicationType.Serial)
+                else if (communication == CommunicationType.Serial)
                 {
                     serialMessagePort?.Close();
                 }


### PR DESCRIPTION
!= CommunicationType.Serial caused Serial port to never be closed and I2C base polling to never stop; changed to ==