### PR TITLE
Fix critical register and pin key bugs in Tca95x5 driver

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Tca95x5/Driver/Tca95x5.DigitalOutputPort.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Tca95x5/Driver/Tca95x5.DigitalOutputPort.cs
@@ -24,8 +24,6 @@ public partial class Tca95x5
             set => controller.SetState(portNumber, value);
         }
 
-        private readonly bool state;
-
         /// <summary>
         /// Gets the digital channel information for the port.
         /// </summary>
@@ -55,10 +53,11 @@ public partial class Tca95x5
         }
 
         /// <summary>
-        /// Disposes of the digital output port.
+        /// Disposes of the digital output port, releasing the pin for reuse.
         /// </summary>
         public void Dispose()
         {
+            controller.ReleasePin(portNumber);
         }
     }
 }

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Tca95x5/Driver/Tca95x5.PinDefinitions.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Tca95x5/Driver/Tca95x5.PinDefinitions.cs
@@ -111,7 +111,7 @@ public partial class Tca95x5
         /// </summary>
         public IPin P10 => new Pin(
             Controller,
-            "P10", (byte)0x10,
+            "P10", (byte)0x08,
             new List<IChannelInfo> {
                 new DigitalChannelInfo("P10", true, true, true, false, false, false)
             }
@@ -122,7 +122,7 @@ public partial class Tca95x5
         /// </summary>
         public IPin P11 => new Pin(
             Controller,
-            "P11", (byte)0x11,
+            "P11", (byte)0x09,
             new List<IChannelInfo> {
                 new DigitalChannelInfo("P11", true, true, true, false, false, false)
             }
@@ -133,7 +133,7 @@ public partial class Tca95x5
         /// </summary>
         public IPin P12 => new Pin(
             Controller,
-            "P12", (byte)0x12,
+            "P12", (byte)0x0A,
             new List<IChannelInfo> {
                 new DigitalChannelInfo("P12", true, true, true, false, false, false)
             }
@@ -144,7 +144,7 @@ public partial class Tca95x5
         /// </summary>
         public IPin P13 => new Pin(
             Controller,
-            "P13", (byte)0x13,
+            "P13", (byte)0x0B,
             new List<IChannelInfo> {
                 new DigitalChannelInfo("P13", true, true, true, false, false, false)
             }
@@ -155,7 +155,7 @@ public partial class Tca95x5
         /// </summary>
         public IPin P14 => new Pin(
             Controller,
-            "P14", (byte)0x14,
+            "P14", (byte)0x0C,
             new List<IChannelInfo> {
                 new DigitalChannelInfo("P14", true, true, true, false, false, false)
             }
@@ -166,7 +166,7 @@ public partial class Tca95x5
         /// </summary>
         public IPin P15 => new Pin(
             Controller,
-            "P15", (byte)0x15,
+            "P15", (byte)0x0D,
             new List<IChannelInfo> {
                 new DigitalChannelInfo("P15", true, true, true, false, false, false)
             }
@@ -177,7 +177,7 @@ public partial class Tca95x5
         /// </summary>
         public IPin P16 => new Pin(
             Controller,
-            "P16", (byte)0x16,
+            "P16", (byte)0x0E,
             new List<IChannelInfo> {
                 new DigitalChannelInfo("P16", true, true, true, false, false, false)
             }
@@ -188,7 +188,7 @@ public partial class Tca95x5
         /// </summary>
         public IPin P17 => new Pin(
             Controller,
-            "P17", (byte)0x17,
+            "P17", (byte)0x0F,
             new List<IChannelInfo> {
                 new DigitalChannelInfo("P17", true, true, true, false, false, false)
             }

--- a/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Tca95x5/Driver/Tca95x5.cs
+++ b/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Tca95x5/Driver/Tca95x5.cs
@@ -9,8 +9,6 @@ namespace Meadow.Foundation.ICs.IOExpanders;
 public abstract partial class Tca95x5 : II2cPeripheral,
     IDigitalInputOutputController
 {
-    private readonly byte address;
-
     /// <inheritdoc/>
     public byte DefaultI2cAddress => (byte)Addresses.Default;
 
@@ -33,14 +31,11 @@ public abstract partial class Tca95x5 : II2cPeripheral,
             Controller = this
         };
 
-        this.address = address;
         i2cComms = new I2cCommunications(i2cBus, address);
     }
 
     private ushort portsInUse = 0x0000;
-    private ushort configRegister = 0xffff; // power-up default is 0xffff
-    private const int Input = 1;
-    private const int Output = 0;
+    private ushort configRegister = 0xffff; // power-up default is 0xffff (all inputs)
 
     /// <inheritdoc/>
     public IDigitalOutputPort CreateDigitalOutputPort(IPin pin, bool initialState = false, OutputType initialOutputType = OutputType.PushPull)
@@ -63,15 +58,10 @@ public abstract partial class Tca95x5 : II2cPeripheral,
         i2cComms.ReadRegister(Registers.ConfigurationPort0, readBuffer);
         var currentConfig = (ushort)(readBuffer[1] << 8 | readBuffer[0]);
 
-        Resolver.Log.Info($"cfg: 0x{configRegister:X4}");
-
         // outputs are zeros - clear this bit
         configRegister = (ushort)(currentConfig & ~bit);
-
-        // write the config
-        Resolver.Log.Info($"setting cfg: 0x{configRegister:X4}");
-        i2cComms.WriteRegister(Registers.ConfigurationPort0, (byte)(configRegister >> 8));
-        i2cComms.WriteRegister(Registers.ConfigurationPort1, (byte)(configRegister & 0xff));
+        i2cComms.WriteRegister(Registers.ConfigurationPort0, (byte)(configRegister & 0xff));
+        i2cComms.WriteRegister(Registers.ConfigurationPort1, (byte)(configRegister >> 8));
 
         return new DigitalOutputPort(this, pin, initialState);
     }
@@ -94,7 +84,6 @@ public abstract partial class Tca95x5 : II2cPeripheral,
         Span<byte> readBuffer = stackalloc byte[2];
         i2cComms.ReadRegister(Registers.OutputPort0, readBuffer);
         var currentState = (ushort)(readBuffer[1] << 8 | readBuffer[0]);
-        Resolver.Log.Info($"current: 0x{currentState:X4}");
 
         if (state)
         {
@@ -104,16 +93,26 @@ public abstract partial class Tca95x5 : II2cPeripheral,
         {
             currentState &= (ushort)~bit;
         }
-        Resolver.Log.Info($"setting: 0x{currentState:X4}");
 
         if (portNumber < 8)
         {
-            i2cComms.WriteRegister(Registers.OutputPort0, (byte)(currentState >> 8));
+            i2cComms.WriteRegister(Registers.OutputPort0, (byte)(currentState & 0xff));
         }
         else
         {
-            i2cComms.WriteRegister(Registers.OutputPort1, (byte)(currentState & 0xff));
+            i2cComms.WriteRegister(Registers.OutputPort1, (byte)(currentState >> 8));
         }
+    }
+
+    internal void ReleasePin(byte portNumber)
+    {
+        ushort bit = (ushort)(1 << portNumber);
+        portsInUse &= (ushort)~bit;
+
+        // restore pin to input mode on the device (set bit = input)
+        configRegister |= bit;
+        i2cComms.WriteRegister(Registers.ConfigurationPort0, (byte)(configRegister & 0xff));
+        i2cComms.WriteRegister(Registers.ConfigurationPort1, (byte)(configRegister >> 8));
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
  - Fix SetState writing high byte to OutputPort0 and low byte to OutputPort1 (swapped)
  - Fix CreateDigitalOutputPort writing config bytes to wrong registers (same swap)
  - Fix Port 1 pin keys (P10-P17) using 0x10-0x17 causing bit shift overflow to zero
  - Fix Dispose not releasing pin from portsInUse or restoring input mode on device
  - Remove debug Resolver.Log.Info calls left in production code
  - Remove unused state field in DigitalOutputPort and unused address field in Tca95x5
  - Remove unused Input/Output constants