### PR TITLE
Add Seeed Wio-E5 LoRa transceiver driver

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/LoRaPacket.cs
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/LoRaPacket.cs
@@ -1,0 +1,32 @@
+namespace Meadow.Foundation.Transceivers;
+
+/// <summary>
+/// Represents a received LoRa packet in P2P test mode
+/// </summary>
+public class LoRaPacket
+{
+    /// <summary>
+    /// Raw payload bytes
+    /// </summary>
+    public byte[] Payload { get; }
+
+    /// <summary>
+    /// Received signal strength in dBm
+    /// </summary>
+    public int Rssi { get; }
+
+    /// <summary>
+    /// Signal-to-noise ratio in dB
+    /// </summary>
+    public int Snr { get; }
+
+    /// <summary>
+    /// Creates a new LoRaPacket
+    /// </summary>
+    public LoRaPacket(byte[] payload, int rssi, int snr)
+    {
+        Payload = payload;
+        Rssi = rssi;
+        Snr = snr;
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/Readme.md
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/Readme.md
@@ -1,0 +1,79 @@
+# Meadow.Foundation.Transceivers.SeeedWioE5
+
+**Seeed Wio-E5 LoRa/LoRaWAN transceiver module**
+
+The **WioE5** library is included in the **Meadow.Foundation.Transceivers.SeeedWioE5** nuget package and is designed for the [Wilderness Labs](www.wildernesslabs.co) Meadow .NET IoT platform.
+
+This driver is part of the [Meadow.Foundation](https://developer.wildernesslabs.co/Meadow/Meadow.Foundation/) peripherals library, an open-source repository of drivers and libraries that streamline and simplify adding hardware to your C# .NET Meadow IoT applications.
+
+For more information on developing for Meadow, visit [developer.wildernesslabs.co](http://developer.wildernesslabs.co/).
+
+To view all Wilderness Labs open-source projects, including samples, visit [github.com/wildernesslabs](https://github.com/wildernesslabs/).
+
+## Installation
+
+You can install the library from within Visual studio using the the NuGet Package Manager or from the command line using the .NET CLI:
+
+`dotnet add package Meadow.Foundation.Transceivers.SeeedWioE5`
+
+## Usage
+
+```csharp
+WioE5 radio;
+
+public override async Task Initialize()
+{
+    Resolver.Log.Info("Initialize...");
+
+    // Grove UART connector on Project Lab V1: com1 (RX=D13, TX=D12)
+    var portName = Device.PlatformOS.GetSerialPortName("com1")!;
+    radio = new WioE5(portName);
+
+    radio.PacketReceived += (s, pkt) =>
+    {
+        var text = System.Text.Encoding.ASCII.GetString(pkt.Payload);
+        Resolver.Log.Info($"RX: \"{text}\" RSSI:{pkt.Rssi}dBm SNR:{pkt.Snr}dB");
+    };
+
+    var ok = await radio.Initialize();
+    Resolver.Log.Info($"Initialize: {(ok ? "OK" : "FAILED")}");
+}
+
+public override async Task Run()
+{
+    await radio.SetTestMode();
+    await radio.ConfigureRf(frequencyHz: 868_000_000);
+
+    await radio.SendPacket(System.Text.Encoding.ASCII.GetBytes("Hello from Meadow"));
+    await radio.StartReceiving();
+}
+```
+
+## How to Contribute
+
+- **Found a bug?** [Report an issue](https://github.com/WildernessLabs/Meadow_Issues/issues)
+- Have a **feature idea or driver request?** [Open a new feature request](https://github.com/WildernessLabs/Meadow_Issues/issues)
+- Want to **contribute code?** Fork the [Meadow.Foundation](https://github.com/WildernessLabs/Meadow.Foundation) repository and submit a pull request against the `develop` branch
+
+
+## Need Help?
+
+If you have questions or need assistance, please join the Wilderness Labs [community on Slack](http://slackinvite.wildernesslabs.co/).
+
+## About Meadow
+
+Meadow is a complete, IoT platform with defense-grade security that runs full .NET applications on embeddable microcontrollers and Linux single-board computers including Raspberry Pi and NVIDIA Jetson.
+
+### Build
+
+Use the full .NET platform and tooling such as Visual Studio and plug-and-play hardware drivers to painlessly build IoT solutions.
+
+### Connect
+
+Utilize native support for WiFi, Ethernet, and Cellular connectivity to send sensor data to the Cloud and remotely control your peripherals.
+
+### Deploy
+
+Instantly deploy and manage your fleet in the cloud for OtA, health-monitoring, logs, command + control, and enterprise backend integrations.
+
+

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/Transceivers.SeeedWioE5.csproj
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/Transceivers.SeeedWioE5.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Meadow.Sdk/1.1.0">
+  <PropertyGroup>
+    <PackageReadmeFile>Readme.md</PackageReadmeFile>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageIcon>icon.png</PackageIcon>
+    <Authors>Wilderness Labs, Inc</Authors>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <OutputType>Library</OutputType>
+    <AssemblyName>Transceivers.SeeedWioE5</AssemblyName>
+    <Company>Wilderness Labs, Inc</Company>
+    <PackageProjectUrl>http://developer.wildernesslabs.co/Meadow/Meadow.Foundation/</PackageProjectUrl>
+    <PackageId>Meadow.Foundation.Transceivers.SeeedWioE5</PackageId>
+    <RepositoryUrl>https://github.com/WildernessLabs/Meadow.Foundation</RepositoryUrl>
+    <PackageTags>Meadow.Foundation, Transceiver, LoRa, LoRaWAN, WioE5, Seeed</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Description>Seeed Wio-E5 LoRa/LoRaWAN module driver (AT command interface over UART)</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include=".\Readme.md" Pack="true" PackagePath="" />
+    <None Include="..\..\..\icon.png" Pack="true" PackagePath="" />
+    <ProjectReference Include="..\..\..\..\..\Meadow.Contracts\Source\Meadow.Contracts\Meadow.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/WioE5.Enums.cs
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/WioE5.Enums.cs
@@ -1,0 +1,46 @@
+namespace Meadow.Foundation.Transceivers;
+
+/// <summary>
+/// LoRa operating mode
+/// </summary>
+public enum LoRaMode
+{
+    /// <summary>LoRaWAN ABP (Activation by Personalization)</summary>
+    LoRaWanAbp,
+    /// <summary>LoRaWAN OTAA (Over-the-Air Activation)</summary>
+    LoRaWanOtaa,
+    /// <summary>P2P test mode</summary>
+    Test
+}
+
+/// <summary>
+/// LoRa spreading factor
+/// </summary>
+public enum SpreadingFactor
+{
+    /// <summary>Spreading factor 7 (highest data rate)</summary>
+    SF7 = 7,
+    /// <summary>Spreading factor 8</summary>
+    SF8 = 8,
+    /// <summary>Spreading factor 9</summary>
+    SF9 = 9,
+    /// <summary>Spreading factor 10</summary>
+    SF10 = 10,
+    /// <summary>Spreading factor 11</summary>
+    SF11 = 11,
+    /// <summary>Spreading factor 12 (longest range)</summary>
+    SF12 = 12
+}
+
+/// <summary>
+/// LoRa signal bandwidth
+/// </summary>
+public enum Bandwidth
+{
+    /// <summary>125 kHz bandwidth</summary>
+    BW125 = 125,
+    /// <summary>250 kHz bandwidth</summary>
+    BW250 = 250,
+    /// <summary>500 kHz bandwidth</summary>
+    BW500 = 500
+}

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/WioE5.TestMode.cs
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/WioE5.TestMode.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Meadow.Foundation.Transceivers;
+
+public partial class WioE5
+{
+    /// <summary>
+    /// Switch to P2P TEST mode
+    /// </summary>
+    public async Task SetTestMode()
+    {
+        await SendCommand("AT+MODE=TEST");
+    }
+
+    /// <summary>
+    /// Configure the RF parameters for P2P test mode
+    /// </summary>
+    public async Task ConfigureRf(
+        int frequencyHz = 868_000_000,
+        SpreadingFactor sf = SpreadingFactor.SF7,
+        Bandwidth bandwidth = Bandwidth.BW125,
+        int txPreamble = 8,
+        int rxPreamble = 8,
+        int powerDbm = 14)
+    {
+        var cmd = $"AT+TEST=RFCFG,{frequencyHz / 1_000_000},{(int)sf},{(int)bandwidth},{txPreamble},{rxPreamble},{powerDbm}";
+        await SendCommand(cmd);
+    }
+
+    /// <summary>
+    /// Transmit a packet in P2P test mode
+    /// </summary>
+    /// <param name="data">Payload bytes to send</param>
+    public async Task<bool> SendPacket(byte[] data)
+    {
+        var hex = BitConverter.ToString(data).Replace("-", "");
+        var response = await SendCommand($"AT+TEST=TXLRPKT,\"{hex}\"", timeoutMs: 10_000);
+
+        foreach (var line in response)
+        {
+            if (line.Contains("TX DONE")) return true;
+            if (line.Contains("ERROR")) return false;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Put the module into continuous receive mode. Raises PacketReceived when a packet arrives.
+    /// </summary>
+    public Task StartReceiving()
+    {
+        _receiving = true;
+        // Write directly — bypasses SendCommand so the command lock stays free
+        _port.Write(System.Text.Encoding.ASCII.GetBytes("AT+TEST=RXLRPKT\r\n"));
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Exit receive mode
+    /// </summary>
+    public async Task StopReceiving()
+    {
+        _receiving = false;
+        await SendCommand("AT");
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/WioE5.cs
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Driver/WioE5.cs
@@ -1,0 +1,228 @@
+using Meadow.Hardware;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Meadow.Foundation.Transceivers;
+
+/// <summary>
+/// Driver for the Seeed Wio-E5 LoRa/LoRaWAN module (AT command interface over UART)
+/// </summary>
+public partial class WioE5 : IDisposable
+{
+    private readonly ISerialMessagePort _port;
+    private readonly bool _createdPort;
+    private readonly SemaphoreSlim _commandLock = new SemaphoreSlim(1, 1);
+    private TaskCompletionSource<string[]>? _pendingResponse;
+    private readonly List<string> _responseLines = new List<string>();
+    private bool _receiving;
+    private int _pendingRxRssi;
+    private int _pendingRxSnr;
+
+    /// <summary>
+    /// Raised when a LoRa packet is received in TEST mode
+    /// </summary>
+    public event EventHandler<LoRaPacket>? PacketReceived;
+
+    /// <summary>
+    /// Create a WioE5 from a pre-created serial message port
+    /// </summary>
+    public WioE5(ISerialMessagePort port)
+    {
+        _port = port;
+        _port.MessageReceived += OnMessageReceived;
+    }
+
+    /// <summary>
+    /// Create a WioE5 from a serial port name
+    /// </summary>
+    public WioE5(SerialPortName portName, int baudRate = 9600)
+        : this(portName.CreateSerialMessagePort(
+            Encoding.ASCII.GetBytes("\r\n"),
+            preserveDelimiter: false,
+            readBufferSize: 512))
+    {
+        _createdPort = true;
+    }
+
+    /// <summary>
+    /// Open the serial port and verify communication with the module
+    /// </summary>
+    public async Task<bool> Initialize()
+    {
+        if (!_port.IsOpen)
+        {
+            _port.Open();
+        }
+
+        // Send a bare CR/LF to interrupt any active RX mode, then wait for the module to settle
+        _port.Write(Encoding.ASCII.GetBytes("\r\n"));
+        await Task.Delay(500);
+
+        var response = await SendCommand("AT");
+        return response.Length > 0 && response[0].Contains("OK");
+    }
+
+    /// <summary>
+    /// Get the firmware version string
+    /// </summary>
+    public async Task<string> GetVersion()
+    {
+        var response = await SendCommand("AT+VER");
+        // +VER: 4.0.11
+        return response.Length > 0 ? response[0].Replace("+VER: ", "") : string.Empty;
+    }
+
+    /// <summary>
+    /// Get device identifiers (DevAddr, DevEui, AppEui)
+    /// </summary>
+    public async Task<(string DevAddr, string DevEui, string AppEui)> GetIds()
+    {
+        var response = await SendCommand("AT+ID");
+        string devAddr = string.Empty, devEui = string.Empty, appEui = string.Empty;
+        foreach (var line in response)
+        {
+            if (line.Contains("DevAddr")) devAddr = line.Split(',')[1].Trim();
+            else if (line.Contains("DevEui")) devEui = line.Split(',')[1].Trim();
+            else if (line.Contains("AppEui")) appEui = line.Split(',')[1].Trim();
+        }
+        return (devAddr, devEui, appEui);
+    }
+
+    private void OnMessageReceived(object sender, SerialMessageData e)
+    {
+        var line = Encoding.ASCII.GetString(e.Message).Trim();
+        if (string.IsNullOrEmpty(line)) return;
+
+        if (_receiving)
+        {
+            // First line: +TEST: LEN:5, RSSI:-42, SNR:7
+            if (line.StartsWith("+TEST: LEN:"))
+            {
+                HandleRxHeader(line);
+                return;
+            }
+            // Second line: +TEST: RX "48656C6C6F"
+            if (line.StartsWith("+TEST: RX "))
+            {
+                HandleRxData(line);
+                return;
+            }
+        }
+
+        // Accumulate response lines for the pending command
+        if (_pendingResponse != null)
+        {
+            _responseLines.Add(line);
+
+            if (IsTerminalLine(line))
+            {
+                var lines = _responseLines.ToArray();
+                _responseLines.Clear();
+                _pendingResponse.TrySetResult(lines);
+            }
+        }
+    }
+
+    private bool IsTerminalLine(string line)
+    {
+        // Single-line responses
+        if (line.StartsWith("+AT:") ||
+            line.StartsWith("+VER:") ||
+            line.StartsWith("+MODE:") ||
+            line.StartsWith("+DR:") ||
+            line.StartsWith("+CH:") ||
+            line.Contains("ERROR"))
+        {
+            return true;
+        }
+
+        // +ID returns three lines (DevAddr, DevEui, AppEui) — terminal on AppEui
+        if (line.StartsWith("+ID:") && line.Contains("AppEui"))
+        {
+            return true;
+        }
+
+        // TEST mode multi-line responses — terminal lines
+        if (line == "+TEST: TX DONE" ||
+            line == "+TEST: CW" ||
+            line.StartsWith("+TEST: RFCFG"))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    internal async Task<string[]> SendCommand(string command, int timeoutMs = 5000)
+    {
+        await _commandLock.WaitAsync();
+        try
+        {
+            _pendingResponse = new TaskCompletionSource<string[]>();
+            _responseLines.Clear();
+
+            _port.Write(Encoding.ASCII.GetBytes(command + "\r\n"));
+
+            var tcs = _pendingResponse;
+            var completed = await Task.WhenAny(tcs.Task, Task.Delay(timeoutMs));
+
+            _pendingResponse = null;
+
+            if (completed == tcs.Task)
+            {
+                return await tcs.Task;
+            }
+
+            return Array.Empty<string>();
+        }
+        finally
+        {
+            _commandLock.Release();
+        }
+    }
+
+    private void HandleRxHeader(string line)
+    {
+        // +TEST: LEN:5, RSSI:-42, SNR:7
+        try
+        {
+            var parts = line.Substring("+TEST: ".Length).Split(',');
+            _pendingRxRssi = int.Parse(parts[1].Split(':')[1].Trim());
+            _pendingRxSnr = int.Parse(parts[2].Split(':')[1].Trim());
+        }
+        catch { }
+    }
+
+    private void HandleRxData(string line)
+    {
+        // +TEST: RX "48656C6C6F"
+        try
+        {
+            var start = line.IndexOf('"') + 1;
+            var hex = line.Substring(start, line.LastIndexOf('"') - start);
+            var bytes = new byte[hex.Length / 2];
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            }
+            PacketReceived?.Invoke(this, new LoRaPacket(bytes, _pendingRxRssi, _pendingRxSnr));
+        }
+        catch { }
+    }
+
+    /// <summary>
+    /// Releases resources used by the WioE5 driver
+    /// </summary>
+    public void Dispose()
+    {
+        _commandLock.Dispose();
+        if (_createdPort && _port.IsOpen)
+        {
+            _port.Close();
+        }
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_Desktop_Sample/DesktopSerialMessagePort.cs
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_Desktop_Sample/DesktopSerialMessagePort.cs
@@ -1,0 +1,100 @@
+using Meadow.Hardware;
+using System;
+using System.Text;
+using System.Threading;
+using SysPorts = System.IO.Ports;
+
+/// <summary>
+/// Minimal ISerialMessagePort implementation backed by System.IO.Ports.SerialPort.
+/// Uses a background read thread — DataReceived is unreliable on Linux.
+/// Used only for desktop testing, not part of the driver itself.
+/// </summary>
+internal class DesktopSerialMessagePort : ISerialMessagePort
+{
+    private readonly SysPorts.SerialPort _port;
+    private readonly byte[] _delimiter;
+    private readonly StringBuilder _accumulator = new StringBuilder();
+    private Thread? _readThread;
+    private volatile bool _running;
+
+    public event EventHandler<SerialMessageData>? MessageReceived;
+
+    public int BaudRate { get => _port.BaudRate; set => _port.BaudRate = value; }
+    public int DataBits => _port.DataBits;
+    public bool IsOpen => _port.IsOpen;
+    public Meadow.Hardware.Parity Parity => (Meadow.Hardware.Parity)_port.Parity;
+    public Meadow.Hardware.StopBits StopBits => (Meadow.Hardware.StopBits)_port.StopBits;
+    public string PortName => _port.PortName;
+    public int ReceiveBufferSize => _port.ReadBufferSize;
+
+    public DesktopSerialMessagePort(string portName, int baudRate, byte[] delimiter)
+    {
+        _delimiter = delimiter;
+        _port = new SysPorts.SerialPort(portName, baudRate)
+        {
+            ReadTimeout = 100
+        };
+    }
+
+    public void Open()
+    {
+        _port.Open();
+        _running = true;
+        _readThread = new Thread(ReadLoop) { IsBackground = true, Name = "SerialReadLoop" };
+        _readThread.Start();
+    }
+
+    public void Close()
+    {
+        _running = false;
+        _port.Close();
+    }
+
+    private void ReadLoop()
+    {
+        var delimStr = Encoding.ASCII.GetString(_delimiter);
+        var buf = new byte[256];
+
+        while (_running)
+        {
+            try
+            {
+                int count = _port.Read(buf, 0, buf.Length);
+                if (count > 0)
+                {
+                    _accumulator.Append(Encoding.ASCII.GetString(buf, 0, count));
+                    var text = _accumulator.ToString();
+                    int idx;
+                    while ((idx = text.IndexOf(delimStr)) >= 0)
+                    {
+                        var message = text[..idx];
+                        _accumulator.Remove(0, idx + delimStr.Length);
+                        text = _accumulator.ToString();
+
+                        if (!string.IsNullOrWhiteSpace(message))
+                        {
+                            MessageReceived?.Invoke(this,
+                                new SerialMessageData { Message = Encoding.ASCII.GetBytes(message) });
+                        }
+                    }
+                }
+            }
+            catch (TimeoutException) { /* normal — no data */ }
+            catch { /* port closed */ break; }
+        }
+    }
+
+    public void ClearReceiveBuffer() => _port.DiscardInBuffer();
+
+    public int Write(byte[] buffer)
+    {
+        _port.Write(buffer, 0, buffer.Length);
+        return buffer.Length;
+    }
+
+    public int Write(byte[] buffer, int offset, int count)
+    {
+        _port.Write(buffer, offset, count);
+        return count;
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_Desktop_Sample/Program.cs
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_Desktop_Sample/Program.cs
@@ -1,0 +1,54 @@
+using Meadow.Foundation.Transceivers;
+using System.Text;
+
+var portName = args.Length > 0 ? args[0] : "/dev/ttyUSB0";
+Console.WriteLine($"Connecting to Wio-E5 on {portName}...");
+
+var serialPort = new DesktopSerialMessagePort(portName, 9600, Encoding.ASCII.GetBytes("\r\n"));
+using var radio = new WioE5(serialPort);
+
+// --- Initialize ---
+var ok = await radio.Initialize();
+Console.WriteLine($"Initialize: {(ok ? "OK" : "FAILED")}");
+if (!ok) return;
+
+var version = await radio.GetVersion();
+Console.WriteLine($"Firmware:   {version}");
+
+var ids = await radio.GetIds();
+Console.WriteLine($"DevEui:     {ids.DevEui}");
+
+// --- Switch to P2P test mode ---
+await radio.SetTestMode();
+Console.WriteLine("Mode:       TEST");
+
+await radio.ConfigureRf(
+    frequencyHz: 868_000_000,
+    sf: SpreadingFactor.SF7,
+    bandwidth: Bandwidth.BW125,
+    powerDbm: 14);
+Console.WriteLine("RF:         868MHz SF7 BW125 14dBm\n");
+
+radio.PacketReceived += (s, pkt) =>
+{
+    var text = Encoding.ASCII.GetString(pkt.Payload);
+    Console.WriteLine($"  RX: \"{text}\"  RSSI:{pkt.Rssi}dBm  SNR:{pkt.Snr}dB");
+};
+
+// --- Mirror loop: TX, then listen for reply, repeat ---
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (s, e) => { e.Cancel = true; cts.Cancel(); };
+
+while (!cts.IsCancellationRequested)
+{
+    Console.WriteLine("Sending packet...");
+    var sent = await radio.SendPacket(Encoding.ASCII.GetBytes("Hello from Desktop"));
+    Console.WriteLine($"TX: {(sent ? "DONE" : "FAILED")}");
+
+    Console.WriteLine("Listening for reply...");
+    await radio.StartReceiving();
+    await Task.Delay(5000, cts.Token).ContinueWith(_ => { });
+    await radio.StopReceiving();
+}
+
+Console.WriteLine("Done.");

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_Desktop_Sample/WioE5_Desktop_Sample.csproj
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_Desktop_Sample/WioE5_Desktop_Sample.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Ports" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Driver\Transceivers.SeeedWioE5.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_ProjectLab_Sample/MeadowApp.cs
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_ProjectLab_Sample/MeadowApp.cs
@@ -1,0 +1,64 @@
+using Meadow;
+using Meadow.Devices;
+using Meadow.Foundation.Transceivers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WioE5_ProjectLab_Sample
+{
+    // Change F7FeatherV2 to F7FeatherV1 for V1.x boards
+    public class MeadowApp : App<F7FeatherV2>
+    {
+        //<!=SNIP=>
+
+        WioE5? radio;
+
+        public override async Task Initialize()
+        {
+            Resolver.Log.Info("Initializing WioE5...");
+
+            // Grove UART connector on Project Lab V1: com1 (RX=D13, TX=D12)
+            var portName = Device.PlatformOS.GetSerialPortName("com1")!;
+            radio = new WioE5(portName);
+
+            radio.PacketReceived += (s, pkt) =>
+            {
+                var text = Encoding.ASCII.GetString(pkt.Payload);
+                Resolver.Log.Info($"RX: \"{text}\" RSSI:{pkt.Rssi}dBm SNR:{pkt.Snr}dB");
+            };
+
+            var ok = await radio.Initialize();
+            Resolver.Log.Info($"Initialize: {(ok ? "OK" : "FAILED")}");
+        }
+
+        public override async Task Run()
+        {
+            if (radio == null) return;
+
+            var version = await radio.GetVersion();
+            Resolver.Log.Info($"Firmware: {version}");
+
+            await radio.SetTestMode();
+            await radio.ConfigureRf(
+                frequencyHz: 868_000_000,
+                sf: SpreadingFactor.SF7,
+                bandwidth: Bandwidth.BW125,
+                powerDbm: 14);
+            Resolver.Log.Info("RF configured: 868MHz SF7 BW125 14dBm");
+
+            while (true)
+            {
+                Resolver.Log.Info("Sending packet...");
+                var sent = await radio.SendPacket(Encoding.ASCII.GetBytes("Hello from Meadow"));
+                Resolver.Log.Info($"TX: {(sent ? "DONE" : "FAILED")}");
+
+                Resolver.Log.Info("Listening for reply...");
+                await radio.StartReceiving();
+                await Task.Delay(5000);
+                await radio.StopReceiving();
+            }
+        }
+
+        //<!=SNOP=>
+    }
+}

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_ProjectLab_Sample/WioE5_ProjectLab_Sample.csproj
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_ProjectLab_Sample/WioE5_ProjectLab_Sample.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Meadow.Sdk/1.1.0">
+  <PropertyGroup>
+    <LangVersion>12.0</LangVersion>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <OutputType>Library</OutputType>
+    <AssemblyName>App</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\..\Meadow.Core\Source\implementations\f7\Meadow.F7\Meadow.F7.csproj" />
+    <ProjectReference Include="..\..\Driver\Transceivers.SeeedWioE5.csproj" />
+  </ItemGroup>
+</Project>

--- a/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_ProjectLab_Sample/app.build.yaml
+++ b/Source/Meadow.Foundation.Peripherals/Transceivers.SeeedWioE5/Samples/WioE5_ProjectLab_Sample/app.build.yaml
@@ -1,0 +1,2 @@
+Deploy:
+  NoLink: [ Transceivers.SeeedWioE5 ]


### PR DESCRIPTION
AT command UART driver for the Seeed Wio-E5 LoRa/LoRaWAN module. Supports P2P test mode with bidirectional packet TX/RX, RF configuration, firmware version and device ID queries. Includes ProjectLab and desktop samples.