### PR TITLE
Fix Bmx280 StartUpdating not syncing oversampling config to chip

### DIFF
--- a/Source/Meadow.Foundation.Peripherals/Sensors.Atmospheric.Bmx280/Driver/Drivers/Bme280.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Atmospheric.Bmx280/Driver/Drivers/Bme280.cs
@@ -299,6 +299,9 @@ public partial class Bme280 :
     public override void StartUpdating(TimeSpan? updateInterval = null)
     {
         configuration.Mode = Modes.Normal;
+        configuration.TemperatureOverSampling = TemperatureSampleCount;
+        configuration.PressureOversampling = PressureSampleCount;
+        configuration.HumidityOverSampling = HumiditySampleCount;
         UpdateConfiguration(configuration);
 
         base.StartUpdating(updateInterval);

--- a/Source/Meadow.Foundation.Peripherals/Sensors.Atmospheric.Bmx280/Driver/Drivers/Bmp280.cs
+++ b/Source/Meadow.Foundation.Peripherals/Sensors.Atmospheric.Bmx280/Driver/Drivers/Bmp280.cs
@@ -278,6 +278,8 @@ public partial class Bmp280 :
     public override void StartUpdating(TimeSpan? updateInterval = null)
     {
         configuration.Mode = Modes.Normal;
+        configuration.TemperatureOverSampling = TemperatureSampleCount;
+        configuration.PressureOversampling = PressureSampleCount;
         UpdateConfiguration(configuration);
 
         base.StartUpdating(updateInterval);


### PR DESCRIPTION
## Problem

`StartUpdating()` on both `Bme280` (and possibly `Bmp280`) produces completely static sensor readings. Values never change, even when breathing on the sensor to adjust humidity or applying heat for temp.

```
[application] Initialize...
[application] Run...
[application] Temp: 26.07C
[application] Humidity: 71.00%
[application] Pressure: 683.38mbar
[application] Temp: 26.07C
[application] Humidity: 71.00%
[application] Pressure: 683.38mbar
[application] Temp: 26.07C
[application] Humidity: 71.00%
[application] Pressure: 683.38mbar
...
```

I'm at ~6,200ft, so that Pressure is definitely off.

## Root Cause

`StartUpdating()` sets the mode to `Normal` and writes the configuration to the chip, but the oversampling fields (`TemperatureOverSampling`, `PressureOversampling`, `HumidityOverSampling`) are still at their default `Oversample.Skip` (0) value.

Per the BME280 datasheet, `Skip` means the measurement is not performed and data registers are not updated. The chip sits in Normal mode but never takes measurements.

Meanwhile, `ReadSensor()` does sync the oversampling properties from the public `SampleCount` fields to the configuration object, but only writes them to the chip when the mode is NOT `Normal` (i.e., in `Forced` mode). So when `StartUpdating()` has already set Normal mode, the oversampling values are never written to the chip.

Explicit `Read()` calls work correctly because they go through the `Forced` mode path in `ReadSensor()`.

## Fix

Sync `TemperatureSampleCount`, `PressureSampleCount`, and `HumiditySampleCount` (BME280 only) to the configuration object in `StartUpdating()` before calling `UpdateConfiguration()`.

## Testing

Verified on a Raspberry Pi 5 with an Adafruit BME280 breakout over I2C. Before the fix, `StartUpdating()` returned identical values every cycle. After the fix, temperature, humidity, and pressure all respond to environmental changes as expected.

```
[application] Initialize...
[application] Run...
[application] Temp: 29.87C
[application] Humidity: 32.00%
[application] Pressure: 818.10mbar
[application] Temp: 29.79C
[application] Humidity: 32.00%
[application] Pressure: 818.10mbar
[application] Temp: 31.70C
[application] Humidity: 37.00%
[application] Pressure: 818.27mbar
[application] Temp: 32.22C
[application] Humidity: 40.00%
[application] Pressure: 818.34mbar
...
```